### PR TITLE
fix: jump instruction typo

### DIFF
--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -318,8 +318,8 @@ um diese Bits zu setzen.
 |--------------------- |---------- |
 | `je`                 | "Jump equal"     -- Springe, wenn der Vergleich ergeben hat, dass die Werte die selben sind |
 | `jne`                | "Jump not equal" -- Springe, wenn der Vergleich ergeben hat, dass die Werte ungleich sind |
-| `jb`                 | "Jump above"     -- Springe wenn $\text{reg1} < \text{reg2}$ oder $\text{reg1} < \text{value}$ (unsigned number) |
-| `ja`                 | "Jump below"     -- Springe wenn $\text{reg1} > \text{reg2}$ oder $\text{reg1} > \text{value}$ (unsigned number) |
+| `ja`                 | "Jump above"     -- Springe wenn $\text{reg1} < \text{reg2}$ oder $\text{reg1} < \text{value}$ (unsigned number) |
+| `jb`                 | "Jump below"     -- Springe wenn $\text{reg1} > \text{reg2}$ oder $\text{reg1} > \text{value}$ (unsigned number) |
 | `jl`                 | "Jump less"      -- Springe wenn $\text{reg1} < \text{reg2}$ oder $\text{reg1} < \text{value}$ (signed number) |
 | `jg`                 | "Jump greater"   -- Springe wenn $\text{reg1} > \text{reg2}$ oder $\text{reg1} > \text{value}$ (signed number) |
 | `jle` / `jge` / ...  | "Jump less equal" / "Jump greater equal" -- Analog zu den Sprüngen oben nur mit equal |


### PR DESCRIPTION
`JA` is Jump above: https://en.wikibooks.org/wiki/X86_Assembly/Control_Flow#Jump_if_Above_(unsigned_comparison)
`JB` is Jump below: https://en.wikibooks.org/wiki/X86_Assembly/Control_Flow#Jump_if_Below_(unsigned_comparison)

Was swapped before (likely typo)