### PR TITLE
fix mistake regarding parity flag

### DIFF
--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -366,8 +366,7 @@ Das Ergebnis wird verworfen, jedoch werden folgende Flags gesetzt:
 
 * `sf`: signed flag, gibt an ob es sich um eine negative Zahl handelt,
 * `zf`: zero flag, gibt an ob das Ergebnis die Zahl 0 repräsentiert,
-* `pf`: parity flag, gibt an ob das Ergebnis gerade/ungerade ist, also gdw.,
-      ob das letzte Bit gesetzt ist.
+* `pf`: parity flag, gibt an ob die Anzahl an gesetzten Bits im niedrigsten Byte gerade ist. 
 
 Anmerkungen:
 


### PR DESCRIPTION
Der Patch behebt einen kleinen Fehler zur Parityflag:
Die Parity Flag gibt nicht an, ob das Ergebnis gerade bzw. das letzte Bit gesetzt ist. Die Parity Flag gibt nur an, ob die Anzahl an gesetzten Bits im niedrigsten (least significant) Byte gerade ist. Dieser kleine aber wichtige Unterschied macht die Verwendung der Parityflag eher selten. Heutzutage wird die Flag fast ausschließlich aus Gründen der Abwärtskompatibilität unterstützt.