### PR TITLE
Add instruction overview, reorder section by most common usage, add 'not'

### DIFF
--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -8,17 +8,28 @@
   <style>
     code{white-space: pre-wrap;}
     span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
     div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
   </style>
   <link rel="stylesheet" href="styles/style.css" />
-  <script src="/usr/share/javascript/mathjax/tex-mml-chtml.js" type="text/javascript"></script>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script src="/usr/share/javascript/mathjax/MathJax.js"
+  type="text/javascript"></script>
 </head>
 <body>
 <header id="title-block-header">
-<h1 class="title">Linux x86 Assembly Cheat Sheet (FU Berlin, TI 2 und 3)</h1>
+<h1 class="title">Linux x86 Assembly Cheat Sheet (FU Berlin, TI 2 und
+3)</h1>
 </header>
 <h1 id="register">Register</h1>
 <table style="background-color: #f8f9fa;color: #202122;margin: 1em 0;border: 1px solid #a2a9b1;border-collapse: collapse;">
@@ -233,7 +244,8 @@ dil
 </caption>
 </table>
 <h2 id="verbotene-register">Verbotene Register</h2>
-<p>Folgende Register sollten nicht benutzt werden. Das schließt die kleineren Register mit ein.</p>
+<p>Folgende Register sollten nicht benutzt werden. Das schließt die
+kleineren Register mit ein.</p>
 <table style="background-color: #f8f9fa;color: #202122;margin: 1em 0;border: 1px solid #a2a9b1;border-collapse: collapse;">
 <tbody>
 <tr>
@@ -288,7 +300,8 @@ r12
 r12d, r12w, r12b
 </td>
 <td>
-Reserviert für interne Abläufe. Kann genutzt werden, falls der Wert manuell gespeichert wurde.
+Reserviert für interne Abläufe. Kann genutzt werden, falls der Wert
+manuell gespeichert wurde.
 </td>
 </tr>
 <tr>
@@ -409,11 +422,26 @@ Stack
 </tbody>
 </table>
 <h2 id="rückgabe-register">Rückgabe-Register</h2>
-<p>Der Rückgabewert einer Funktion steht im <code>rax</code> Register. Achtet dabei darauf, dass ihr euer Ergebnis immer ins rax Register schreibt.</p>
-<p>Für Floating-Point-Zahlen steht das Ergebnis einer Funktion im <code>xmm0</code> Register.</p>
-<h2 id="volatile--vs.-non-volatile-register">Volatile- vs. Non-Volatile-Register</h2>
-<p>Nach Calling-Convention werden die Register in 2 Kategorien eingeteilt: Volatile und Non-Volatile. Non-Volatile-Register behalten, nach Calling-Convention, nach einem Funktionsaufruf ihren Wert. D.h. wir müssen uns nicht um die Sicherung dieser Register kümmern, wenn wir eine weitere Funktion aufrufen. Dies bedeutet aber auch automatisch, dass wir diese Register auf dem Stack sichern müssen (<code>push</code>), wenn wir sie verwenden wollen, und sie wiederherstellen (<code>pop</code>) bevor unsere Funktion beendet.</p>
-<p>Volatile-Register auf der anderen Seite verhalten sich genau andersherum: Wir dürfen die Wert die dort gespeichert sind verändern, ohne uns um eine Sicherung Gedanken machen zu müssen. Wollen wir jedoch ihren Wert über einen weiteren Funktionsaufruf behalten, müssen wir sie manuell vor dem Aufruf sichern.</p>
+<p>Der Rückgabewert einer Funktion steht im <code>rax</code> Register.
+Achtet dabei darauf, dass ihr euer Ergebnis immer ins rax Register
+schreibt.</p>
+<p>Für Floating-Point-Zahlen steht das Ergebnis einer Funktion im
+<code>xmm0</code> Register.</p>
+<h2 id="volatile--vs.-non-volatile-register">Volatile-
+vs. Non-Volatile-Register</h2>
+<p>Nach Calling-Convention werden die Register in 2 Kategorien
+eingeteilt: Volatile und Non-Volatile. Non-Volatile-Register behalten,
+nach Calling-Convention, nach einem Funktionsaufruf ihren Wert. D.h. wir
+müssen uns nicht um die Sicherung dieser Register kümmern, wenn wir eine
+weitere Funktion aufrufen. Dies bedeutet aber auch automatisch, dass wir
+diese Register auf dem Stack sichern müssen (<code>push</code>), wenn
+wir sie verwenden wollen, und sie wiederherstellen (<code>pop</code>)
+bevor unsere Funktion beendet.</p>
+<p>Volatile-Register auf der anderen Seite verhalten sich genau
+andersherum: Wir dürfen die Wert die dort gespeichert sind verändern,
+ohne uns um eine Sicherung Gedanken machen zu müssen. Wollen wir jedoch
+ihren Wert über einen weiteren Funktionsaufruf behalten, müssen wir sie
+manuell vor dem Aufruf sichern.</p>
 <table>
 <thead>
 <tr class="header">
@@ -477,13 +505,18 @@ Stack
 </table>
 <h1 id="befehle">Befehle</h1>
 <h2 id="bewegen-von-daten">Bewegen von Daten:</h2>
-<h3 id="mov-reg-to-value-mov-reg-to-reg-from">mov reg (to), value / mov reg (to), reg (from):</h3>
-<p>Definition: Verschiebe ein Wert bzw. den Wert eines Registers in ein weiteres Register.</p>
+<h3 id="mov-reg-to-value-mov-reg-to-reg-from">mov reg (to), value / mov
+reg (to), reg (from):</h3>
+<p>Definition: Verschiebe ein Wert bzw. den Wert eines Registers in ein
+weiteres Register.</p>
 <p>Beispiel:</p>
 <pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
-<h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1), value / shl reg (value 1), cl</h3>
-<p>Definition: Shifte den Wert des Registers um <span class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links “rausgeschoben” werden gehen verloren</p>
+<h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1),
+value / shl reg (value 1), cl</h3>
+<p>Definition: Shifte den Wert des Registers um <span
+class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
+“rausgeschoben” werden gehen verloren</p>
 <p>Beispiel:</p>
 <pre><code>shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
 shl rax, 1   ; Verschiebe alle Bits</code></pre>
@@ -493,15 +526,28 @@ shl rax, 1   ; Verschiebe alle Bits</code></pre>
 shl rax, 1
 
 =&gt; rax = 1000 0110</code></pre>
-<p>ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register <code>cl</code> als Registerverschiebungswert nehmen! Dies ist dadurch begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung des Count-Registers (<code>cl</code>) angelegt wurde für Verschiebungen.</p>
-<h3 id="shr-reg-value-1-value-shr-reg-value-1-cl">shr reg (value 1), value / shr reg (value 1), cl</h3>
-<p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts. Also analog zu <code>shl</code>.</p>
+<p>ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register
+<code>cl</code> als Registerverschiebungswert nehmen! Dies ist dadurch
+begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
+des Count-Registers (<code>cl</code>) angelegt wurde für
+Verschiebungen.</p>
+<h3 id="shr-reg-value-1-value-shr-reg-value-1-cl">shr reg (value 1),
+value / shr reg (value 1), cl</h3>
+<p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
+Also analog zu <code>shl</code>.</p>
 <p>Beispiel:</p>
 <pre><code>shr rax, cl
 shr rax, 1</code></pre>
-<p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> können nur das Register <code>cl</code> als Registerverschiebungswert nutzen! Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
-<h3 id="rol-reg-value-1-value-rol-reg-value-1-reg-value-2">rol reg (value 1), value / rol reg (value 1), reg (value 2)</h3>
-<p>Definition: Rotiere die Werte um <span class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch gehen hier die Bits die nach links raus geschoben werden nicht verloren, sondern werden rechts hinzugefügt.</p>
+<p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> können
+nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
+Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
+Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
+<h3 id="rol-reg-value-1-value-rol-reg-value-1-reg-value-2">rol reg
+(value 1), value / rol reg (value 1), reg (value 2)</h3>
+<p>Definition: Rotiere die Werte um <span
+class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
+gehen hier die Bits die nach links raus geschoben werden nicht verloren,
+sondern werden rechts hinzugefügt.</p>
 <p>Beispiel:</p>
 <pre><code>rol rax, rdx
 rol rax, 1</code></pre>
@@ -510,14 +556,21 @@ rol rax, 1</code></pre>
 
 rol rax, 1
 =&gt; rax = 1000 1001</code></pre>
-<h3 id="ror-reg-value-1-value-ror-reg-value-1-reg-value-2">ror reg (value 1), value / ror reg (value 1), reg (value 2)</h3>
-<p>Definition: Rotiere die Werte um <span class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu <code>rol</code></p>
+<h3 id="ror-reg-value-1-value-ror-reg-value-1-reg-value-2">ror reg
+(value 1), value / ror reg (value 1), reg (value 2)</h3>
+<p>Definition: Rotiere die Werte um <span
+class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
+<code>rol</code></p>
 <p>Beispiel:</p>
 <pre><code>ror rax, rdx
 ror rax, 1</code></pre>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
-<h3 id="and-reg-value-1-value-and-reg-value-1-reg-value-2">and reg (value 1), value / and reg (value 1), reg (value 2)</h3>
-<p>Definition: Wendet das logische UND (<span class="math inline">\(\land\)</span>) mit dem Wert des zweiten Parameters auf den Wert des ersten Registers an und speichert das Ergebnis im ersten Register.</p>
+<h3 id="and-reg-value-1-value-and-reg-value-1-reg-value-2">and reg
+(value 1), value / and reg (value 1), reg (value 2)</h3>
+<p>Definition: Wendet das logische UND (<span
+class="math inline">\(\land\)</span>) mit dem Wert des zweiten
+Parameters auf den Wert des ersten Registers an und speichert das
+Ergebnis im ersten Register.</p>
 <p>Beispiel:</p>
 <pre><code>and rax, rsi ; Verunde den Wert aus rax mit dem Wert aus rsi
 and rax, 0x1 ; Verunde den Wert aus rax mit dem Wert 0x1 (Hexadezimal-Zahl)</code></pre>
@@ -531,8 +584,12 @@ and rax, rsi = 0101 1101 and 1101 1011
 1001 1011
 ---------
 0001 1001 = rax</code></pre>
-<h3 id="or-reg-value-1-value-or-reg-value-1-reg-value-2">or reg (value 1), value / or reg (value 1), reg (value 2)</h3>
-<p>Definition: Wende das logische ODER (<span class="math inline">\(\lor\)</span>) mit dem Wert des zweiten Parameters auf das erste Register an und speichert das Ergebnis im ersten Register.</p>
+<h3 id="or-reg-value-1-value-or-reg-value-1-reg-value-2">or reg (value
+1), value / or reg (value 1), reg (value 2)</h3>
+<p>Definition: Wende das logische ODER (<span
+class="math inline">\(\lor\)</span>) mit dem Wert des zweiten Parameters
+auf das erste Register an und speichert das Ergebnis im ersten
+Register.</p>
 <p>Beispiel:</p>
 <pre><code>or rax, rsi ; Veroder den Wert aus rax mit dem Wert aus rsi
 or rdx, 0xf ; Veroder den Wert aus rdx mit dem Wert 0xf (Binär = 1111)</code></pre>
@@ -546,8 +603,11 @@ or rdx, 0xf = 0011 1101 or 0000 1101
 0000 1101
 ---------
 0011 1101 = rdx</code></pre>
-<h3 id="xor-reg-value-1-value-xor-reg-value-1-reg-value-2">xor reg (value 1), value / xor reg (value 1), reg (value 2):</h3>
-<p>Definition: Wendet das logische XOR (<span class="math inline">\(\oplus\)</span>) mit dem Wert des zweiten Parameters auf den Wert des ersten Registers an.</p>
+<h3 id="xor-reg-value-1-value-xor-reg-value-1-reg-value-2">xor reg
+(value 1), value / xor reg (value 1), reg (value 2):</h3>
+<p>Definition: Wendet das logische XOR (<span
+class="math inline">\(\oplus\)</span>) mit dem Wert des zweiten
+Parameters auf den Wert des ersten Registers an.</p>
 <p>Beispiel:</p>
 <pre><code>xor rax, rsi  ; Wendet XOR auf den Wert von rax mit dem Wert von rsi an
 xor rdx, 0x8f ; Wendet XOR auf den Wert von rdx mit 0x8f (Binär = 1000 1111) an</code></pre>
@@ -563,41 +623,64 @@ xor rdx, 0x8f
 0000 1011 = rdx</code></pre>
 <h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
 <h3 id="neg-reg-value-1">neg reg (value 1):</h3>
-<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er Komplement).</p>
+<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
+Komplement).</p>
 <p>Beispiel:</p>
 <pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
-<h3 id="add-reg-value-1-value-add-reg-value-1-reg-value-2">add reg (value 1), value / add reg (value 1), reg (value 2):</h3>
-<p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den Wert eines anderen Registers.</p>
+<h3 id="add-reg-value-1-value-add-reg-value-1-reg-value-2">add reg
+(value 1), value / add reg (value 1), reg (value 2):</h3>
+<p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
+Wert eines anderen Registers.</p>
 <p>Beispiel:</p>
 <pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
 add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
-<h3 id="sub-reg-value-1-value-sub-reg-value-1-reg-value-2">sub reg (value 1), value / sub reg (value 1), reg (value 2):</h3>
+<h3 id="sub-reg-value-1-value-sub-reg-value-1-reg-value-2">sub reg
+(value 1), value / sub reg (value 1), reg (value 2):</h3>
 <p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
 <p>Beispiele:</p>
 <pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
 sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
 <h3 id="mul-reg-value-1">mul reg (value 1):</h3>
-<p>Definition: Multipliziere den Wert in Register rax mit dem Wert des angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em> Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in rax passiert)</p>
+<p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
+angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>
+Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in
+rax passiert)</p>
 <p>Beispiel:</p>
 <pre><code>mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</code></pre>
-<p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden. Falls man das Register rax mit einem bestimmten Wert multiplizieren möchte muss man diesen vorher in ein Register verschieben:</p>
+<p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden.
+Falls man das Register rax mit einem bestimmten Wert multiplizieren
+möchte muss man diesen vorher in ein Register verschieben:</p>
 <pre><code>mov rsi, 3
 mul rsi    ; Multipliziere rax mit 3</code></pre>
 <h3 id="div-reg-value-1">div reg (value 1):</h3>
-<p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax) durch den Wert aus dem angegebenen Register. Ergebnis wird in rax (ganzzahlige Division) und rdx (Rest) gespeichert</p>
+<p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax)
+durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
+(ganzzahlige Division) und rdx (Rest) gespeichert</p>
 <p>Beispiel:</p>
 <pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
-<p>ACHTUNG: Prüfe vor der Division, ob der Wert, der sich in rdx befindet, korrekt ist. Dort könnte sich 1. ein Wert befinden, der nichts mit der gewollten Rechnung zu tun hat und 2. ein Wert drin befinden der nach der Division erhalten bleiben sollte.</p>
-<h3 id="imul-reg-value-1-und-idiv-reg-value-1">imul reg (value 1) und idiv reg (value 1):</h3>
-<p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen mit Vorzeichen)</p>
-<h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und Bedinge Sprünge:</h2>
-<h3 id="cmp-reg-value-1-value-cmp-reg-value-1-reg-value-2">cmp reg (value 1), value / cmp reg (value 1), reg (value 2):</h3>
-<p>Definition: Vergleiche ein Register mit einem Wert bzw. mit dem Wert eines weiteren Registers. Diese Operation setzt Bits im Flag-Register die später für Bedingte-Sprünge verwendet werden könnten</p>
+<p>ACHTUNG: Prüfe vor der Division, ob der Wert, der sich in rdx
+befindet, korrekt ist. Dort könnte sich 1. ein Wert befinden, der nichts
+mit der gewollten Rechnung zu tun hat und 2. ein Wert drin befinden der
+nach der Division erhalten bleiben sollte.</p>
+<h3 id="imul-reg-value-1-und-idiv-reg-value-1">imul reg (value 1) und
+idiv reg (value 1):</h3>
+<p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen
+mit Vorzeichen)</p>
+<h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und
+Bedinge Sprünge:</h2>
+<h3 id="cmp-reg-value-1-value-cmp-reg-value-1-reg-value-2">cmp reg
+(value 1), value / cmp reg (value 1), reg (value 2):</h3>
+<p>Definition: Vergleiche ein Register mit einem Wert bzw. mit dem Wert
+eines weiteren Registers. Diese Operation setzt Bits im Flag-Register
+die später für Bedingte-Sprünge verwendet werden könnten</p>
 <p>Beispiel:</p>
 <pre><code>cmp rax, rsi ; Vergleiche rax mit dem Wert aus rsi
 cmp rax, 2   ; Vergleiche rax mit dem Wert 2</code></pre>
 <h3 id="jmp-some_label">jmp some_label:</h3>
-<p>Definition: Setze den Programm Counter (PC, bzw. <code>rip</code>) auf die Adresse des angegebenen Labels (<code>some_label</code>). An Stelle eines Labels kann auch direkt eine Zahl als Adresse genutzt werden (<code>jmp 100</code>).</p>
+<p>Definition: Setze den Programm Counter (PC, bzw. <code>rip</code>)
+auf die Adresse des angegebenen Labels (<code>some_label</code>). An
+Stelle eines Labels kann auch direkt eine Zahl als Adresse genutzt
+werden (<code>jmp 100</code>).</p>
 <p>Beispiel:</p>
 <pre><code>; [...]
 jmp .some_label
@@ -605,8 +688,13 @@ jmp .some_label
 
 .some_label:
 ; [Do something]</code></pre>
-<h3 id="jl-some_label-jb-some_label-jg-some_label-ja-some_label-je-some_label-jne-some_label">jl some_label / jb some_label / jg some_label / ja some_label / je some_label / jne some_label …</h3>
-<p>Definition: Springe, wenn bestimmte Bits im Flag-Register gesetzt sind. Dies wird in der Regel in Kombination mit einer Vergleich-Operation genutzt, um diese Bits zu setzen.</p>
+<h3
+id="jl-some_label-jb-some_label-jg-some_label-ja-some_label-je-some_label-jne-some_label">jl
+some_label / jb some_label / jg some_label / ja some_label / je
+some_label / jne some_label …</h3>
+<p>Definition: Springe, wenn bestimmte Bits im Flag-Register gesetzt
+sind. Dies wird in der Regel in Kombination mit einer
+Vergleich-Operation genutzt, um diese Bits zu setzen.</p>
 <table>
 <colgroup>
 <col style="width: 67%" />
@@ -621,39 +709,53 @@ jmp .some_label
 <tbody>
 <tr class="odd">
 <td><code>je</code></td>
-<td>“Jump equal” – Springe, wenn der Vergleich ergeben hat, dass die Werte die selben sind</td>
+<td>“Jump equal” – Springe, wenn der Vergleich ergeben hat, dass die
+Werte die selben sind</td>
 </tr>
 <tr class="even">
 <td><code>jne</code></td>
-<td>“Jump not equal” – Springe, wenn der Vergleich ergeben hat, dass die Werte ungleich sind</td>
+<td>“Jump not equal” – Springe, wenn der Vergleich ergeben hat, dass die
+Werte ungleich sind</td>
 </tr>
 <tr class="odd">
 <td><code>jb</code></td>
-<td>“Jump below” – Springe wenn <span class="math inline">\(\text{reg1} &lt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1} &lt; \text{value}\)</span> (unsigned number)</td>
+<td>“Jump below” – Springe wenn <span class="math inline">\(\text{reg1}
+&lt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1}
+&lt; \text{value}\)</span> (unsigned number)</td>
 </tr>
 <tr class="even">
 <td><code>ja</code></td>
-<td>“Jump above” – Springe wenn <span class="math inline">\(\text{reg1} &gt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1} &gt; \text{value}\)</span> (unsigned number)</td>
+<td>“Jump above” – Springe wenn <span class="math inline">\(\text{reg1}
+&gt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1}
+&gt; \text{value}\)</span> (unsigned number)</td>
 </tr>
 <tr class="odd">
 <td><code>jl</code></td>
-<td>“Jump less” – Springe wenn <span class="math inline">\(\text{reg1} &lt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1} &lt; \text{value}\)</span> (signed number)</td>
+<td>“Jump less” – Springe wenn <span class="math inline">\(\text{reg1}
+&lt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1}
+&lt; \text{value}\)</span> (signed number)</td>
 </tr>
 <tr class="even">
 <td><code>jg</code></td>
-<td>“Jump greater” – Springe wenn <span class="math inline">\(\text{reg1} &gt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1} &gt; \text{value}\)</span> (signed number)</td>
+<td>“Jump greater” – Springe wenn <span
+class="math inline">\(\text{reg1} &gt; \text{reg2}\)</span> oder <span
+class="math inline">\(\text{reg1} &gt; \text{value}\)</span> (signed
+number)</td>
 </tr>
 <tr class="odd">
 <td><code>jz</code></td>
-<td>“Jump zero” – Äquivalent zu <code>je</code>. Springe wenn das Ergebnis 0 ist.</td>
+<td>“Jump zero” – Äquivalent zu <code>je</code>. Springe wenn das
+Ergebnis 0 ist.</td>
 </tr>
 <tr class="even">
 <td><code>jnz</code></td>
-<td>“Jump not zero” – Äquivalent zu <code>jne</code>. Springe wenn das Ergebnis nicht 0 ist.</td>
+<td>“Jump not zero” – Äquivalent zu <code>jne</code>. Springe wenn das
+Ergebnis nicht 0 ist.</td>
 </tr>
 <tr class="odd">
 <td><code>jle</code> / <code>jge</code> / …</td>
-<td>“Jump less equal” / “Jump greater equal” – Analog zu den Sprüngen oben nur mit equal</td>
+<td>“Jump less equal” / “Jump greater equal” – Analog zu den Sprüngen
+oben nur mit equal</td>
 </tr>
 </tbody>
 </table>
@@ -666,38 +768,72 @@ jl .some_label
 
 .some_label:
 ; execute here if rax &lt; 2</code></pre>
-<h3 id="test-reg-value-1-value-test-reg-value-1-reg-value-2">test reg (value 1), value / test reg (value 1), reg (value 2):</h3>
-<p>Definition: Führt ein logisches UND (<span class="math inline">\(\land\)</span>) auf das erste Register mit dem Wert des zweiten Registers bzw. dem angegebenen Wert aus. Das Ergebnis wird verworfen, jedoch werden folgende Flags gesetzt:</p>
+<h3 id="test-reg-value-1-value-test-reg-value-1-reg-value-2">test reg
+(value 1), value / test reg (value 1), reg (value 2):</h3>
+<p>Definition: Führt ein logisches UND (<span
+class="math inline">\(\land\)</span>) auf das erste Register mit dem
+Wert des zweiten Registers bzw. dem angegebenen Wert aus. Das Ergebnis
+wird verworfen, jedoch werden folgende Flags gesetzt:</p>
 <ul>
-<li><code>sf</code>: signed flag, gibt an ob es sich um eine negative Zahl handelt,</li>
-<li><code>zf</code>: zero flag, gibt an ob das Ergebnis die Zahl 0 repräsentiert,</li>
-<li><code>pf</code>: parity flag, gibt an ob die Anzahl an gesetzten Bits im niedrigsten Byte gerade ist.</li>
+<li><code>sf</code>: signed flag, gibt an ob es sich um eine negative
+Zahl handelt,</li>
+<li><code>zf</code>: zero flag, gibt an ob das Ergebnis die Zahl 0
+repräsentiert,</li>
+<li><code>pf</code>: parity flag, gibt an ob die Anzahl an gesetzten
+Bits im niedrigsten Byte gerade ist.</li>
 </ul>
 <p>Anmerkungen:</p>
 <ul>
-<li><code>je</code>/<code>jz</code> testet, ob das <code>zf</code>-Bit gesetzt ist. Also wenn hier die Verundung das Ergebnis 0 ergab.</li>
+<li><code>je</code>/<code>jz</code> testet, ob das <code>zf</code>-Bit
+gesetzt ist. Also wenn hier die Verundung das Ergebnis 0 ergab.</li>
 </ul>
 <h2 id="sichern-von-daten">Sichern von Daten:</h2>
 <h3 id="grundlagen-stack">Grundlagen Stack:</h3>
-<p>Ein Stack ist eine Datenstruktur die einer Last-In-First-Out-Warteschlange entspringt. D.h. das letzte Element welches hinzugefügt wurde wird das erste Element sein, welches entnommen wird. Die CPU nutzt einen solchen Stack für diverse Operationen, und es gibt Assembly Instruktionen um auf diesen direkt zuzugreifen. Zusätzlich werden zwei Werte vorgehalten: der (Stack-)Base-Pointer (oder Frame-Pointer) und der Stack-Pointer. Der Base-Pointer zeigt immer auf den Beginn des Stacks währenddessen der Stack-Pointer auf die nächste freie Adresse zeigt.</p>
-<p>WICHTIG: nach dem Funktionsaufruf (also vor dem ret Befehl) muss der Stack-Pointer wieder auf der selben Stelle sein wie zu Beginn des Funktionsaufrufs!</p>
+<p>Ein Stack ist eine Datenstruktur die einer
+Last-In-First-Out-Warteschlange entspringt. D.h. das letzte Element
+welches hinzugefügt wurde wird das erste Element sein, welches entnommen
+wird. Die CPU nutzt einen solchen Stack für diverse Operationen, und es
+gibt Assembly Instruktionen um auf diesen direkt zuzugreifen. Zusätzlich
+werden zwei Werte vorgehalten: der (Stack-)Base-Pointer (oder
+Frame-Pointer) und der Stack-Pointer. Der Base-Pointer zeigt immer auf
+den Beginn des Stacks währenddessen der Stack-Pointer auf die nächste
+belegte Adresse zeigt. Der Stack wächst, wenn <code>rsp</code> kleiner
+wird. Daher “wächst” der Stack nach unten. (Der Stack ist “full
+descending”.)</p>
+<p>WICHTIG: nach dem Funktionsaufruf (also vor dem ret Befehl) muss der
+Stack-Pointer wieder auf der selben Stelle sein wie zu Beginn des
+Funktionsaufrufs!</p>
 <h3 id="push-reg">push reg:</h3>
-<p>Definition: Um Daten auf den Stack zu legen nutzt man den <code>push</code>-Befehl. Dieser legt dann den Wert des angegebenen Registers auf den Stack ab und aktualisiert den Stack-Pointer.</p>
+<p>Definition: Um Daten auf den Stack zu legen nutzt man den
+<code>push</code>-Befehl. Dieser legt dann den Wert des angegebenen
+Registers auf den Stack ab und aktualisiert den Stack-Pointer.</p>
 <p>Beispiel:</p>
 <pre><code>push rax
 push esi
 push cl</code></pre>
 <h3 id="pop-reg">pop reg:</h3>
-<p>Definition: Um Daten vom Stack wieder zu nehmen nutzt man den <code>pop</code>-Befehl. Dieser lädt das Datum welches zuletzt auf den Stack gelegt wurde und speichert es in das jeweilige Register.</p>
+<p>Definition: Um Daten vom Stack wieder zu nehmen nutzt man den
+<code>pop</code>-Befehl. Dieser lädt das Datum welches zuletzt auf den
+Stack gelegt wurde und speichert es in das jeweilige Register.</p>
 <p>Beispiel:</p>
 <pre><code>pop cl
 pop esi
 pop rax</code></pre>
-<p>WICHTIG: Es muss in umgekehrter Reigenfolge gepoppt werden wie die Elemente gepusht wurde. Dies ist der Fall wegen der LIFO-Struktur des Stacks!</p>
-<h2 id="aufrufen-einer-weiteren-funktion">Aufrufen einer weiteren Funktion:</h2>
+<p>WICHTIG: Es muss in umgekehrter Reigenfolge gepoppt werden wie die
+Elemente gepusht wurde. Dies ist der Fall wegen der LIFO-Struktur des
+Stacks!</p>
+<h2 id="aufrufen-einer-weiteren-funktion">Aufrufen einer weiteren
+Funktion:</h2>
 <h3 id="call-some_label">call some_label:</h3>
-<p>Definition: Die <code>call</code>-Instruktion wird genutzt um eine Subroutine aufzurufen. Anders als beim <code>jmp</code>-Befehl wird nach der jeweiligen Subroutine wieder an die Stelle des <code>call</code> zurückgesprungen. D.h. das beim Aufruf eines <code>call</code>-Befehls der PC (<code>rip</code>) auf den Stack gepusht werden bevor der Sprung zur jeweiligen Adresse durchgeführt wird.</p>
-<p>WICHTIG: Achtet beim Aufruf der <code>call</code>-Instruktion darauf, dass ihr die Calling-Convention beachtet (bspw. Eingaberegister füllen oder jeweilige Register sichern)</p>
+<p>Definition: Die <code>call</code>-Instruktion wird genutzt um eine
+Subroutine aufzurufen. Anders als beim <code>jmp</code>-Befehl wird nach
+der jeweiligen Subroutine wieder an die Stelle des <code>call</code>
+zurückgesprungen. D.h. das beim Aufruf eines <code>call</code>-Befehls
+der PC (<code>rip</code>) auf den Stack gepusht werden bevor der Sprung
+zur jeweiligen Adresse durchgeführt wird.</p>
+<p>WICHTIG: Achtet beim Aufruf der <code>call</code>-Instruktion darauf,
+dass ihr die Calling-Convention beachtet (bspw. Eingaberegister füllen
+oder jeweilige Register sichern)</p>
 <p>Beispiel:</p>
 <pre><code>some_function:
     ...
@@ -709,10 +845,17 @@ some_other_function:
     ...
     ret</code></pre>
 <h1 id="assembly-tricks">Assembly-Tricks:</h1>
-<h3 id="ein-register-auf-0-setzen-clean-oder-bereinigen">Ein Register auf 0 setzen (“clean” oder “bereinigen”)</h3>
-<p>Um den Wert eines Registers auf 0 zu setzen könnt ihr einfach die Zahl 0 in das jeweilige Register setzen:</p>
+<h3 id="ein-register-auf-0-setzen-clean-oder-bereinigen">Ein Register
+auf 0 setzen (“clean” oder “bereinigen”)</h3>
+<p>Um den Wert eines Registers auf 0 zu setzen könnt ihr einfach die
+Zahl 0 in das jeweilige Register setzen:</p>
 <pre><code>mov rax, 0 ; Setze rax = 0</code></pre>
-<p>Optional hierzu könnt ihr die <code>xor</code>-Instruktion nutzen. Da XOR ein gegebenen Bit auf 0 setzt, gdw. beide Register-Einträge 0 sind, ODER beide Registereinträge 1 sind folgt daraus, dass ein XOR mit dem selben Wert das jeweilige Register auf 0 setzen wird. Dies hat also den selben Effekt wie ein <code>mov</code> Befehl und <em>kann</em> unter Umständen effizienter sein (konkret ist die Codierungslänge kürzer).</p>
+<p>Optional hierzu könnt ihr die <code>xor</code>-Instruktion nutzen. Da
+XOR ein gegebenen Bit auf 0 setzt, gdw. beide Register-Einträge 0 sind,
+ODER beide Registereinträge 1 sind folgt daraus, dass ein XOR mit dem
+selben Wert das jeweilige Register auf 0 setzen wird. Dies hat also den
+selben Effekt wie ein <code>mov</code> Befehl und <em>kann</em> unter
+Umständen effizienter sein (konkret ist die Codierungslänge kürzer).</p>
 <pre><code>xor rax, rax ; Setze rax = 0
 
 e.g rax = 1101 1111
@@ -723,8 +866,14 @@ xor rax, rax
 1101 1111
 ---------
 0000 0000</code></pre>
-<h3 id="ganzzahlige-multiplikationdivision-um-eine-zweier-potenz">Ganzzahlige Multiplikation/Division um eine zweier Potenz</h3>
-<p>Die Multiplikation bzw. die Division einer Zahl der Basis <span class="math inline">\(b\)</span> mit einer Zahl der Form <span class="math inline">\(b^n\)</span> kann als einfache “Verschiebung” um <span class="math inline">\(n\)</span> Stellen betrachtet werden. Gucken wir uns dies zuerst im Dezimalsystem mit 10-er Potenzen an:</p>
+<h3
+id="ganzzahlige-multiplikationdivision-um-eine-zweier-potenz">Ganzzahlige
+Multiplikation/Division um eine zweier Potenz</h3>
+<p>Die Multiplikation bzw. die Division einer Zahl der Basis <span
+class="math inline">\(b\)</span> mit einer Zahl der Form <span
+class="math inline">\(b^n\)</span> kann als einfache “Verschiebung” um
+<span class="math inline">\(n\)</span> Stellen betrachtet werden. Gucken
+wir uns dies zuerst im Dezimalsystem mit 10-er Potenzen an:</p>
 <p><span class="math display">\[\begin{align*}
     12 \cdot 10^1 &amp;= 12 \cdot 10   &amp;&amp;= 120 \\
     12 \cdot 10^2 &amp;= 12 \cdot 100  &amp;&amp;= 1200 \\
@@ -737,19 +886,28 @@ xor rax, rax
 \end{align*}\]</span></p>
 <p>Im Binärsystem gilt dieses Prinzip natürlich auch:</p>
 <p><span class="math display">\[\begin{align*}
-    0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10} &amp;&amp;= 0110_2 \\
+    0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10} &amp;&amp;= 0110_2
+\\
     0011_2 \cdot 2_{10}^2 &amp;= 0011_2 \cdot 4_{10} &amp;&amp;= 1100_2
 \end{align*}\]</span></p>
 <p><span class="math display">\[\begin{align*}
-    0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10} &amp;&amp;= 0001(.1000)_2 \\
-    0011_2 \div 2_{10}^2 &amp;= 0011_2 \div 4_{10} &amp;&amp;= 0000(.1100)_2
+    0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10} &amp;&amp;=
+0001(.1000)_2 \\
+    0011_2 \div 2_{10}^2 &amp;= 0011_2 \div 4_{10} &amp;&amp;=
+0000(.1100)_2
 \end{align*}\]</span></p>
 <p>Hinweise:</p>
 <ol type="1">
-<li>Wir geben mit den Subscripts die Basis der Zahlendarstellung an.</li>
-<li>Da wir mit Binärdarstellungen fester Größe arbeiten können die Zahlen hinter dem Komma nicht dargestellt werden. Daher sind nur ganzzahlige Division möglich.</li>
+<li>Wir geben mit den Subscripts die Basis der Zahlendarstellung
+an.</li>
+<li>Da wir mit Binärdarstellungen fester Größe arbeiten können die
+Zahlen hinter dem Komma nicht dargestellt werden. Daher sind nur
+ganzzahlige Division möglich.</li>
 </ol>
-<p>In Assembly können wir also eine Multiplikation bzw. Division eines Registers mit einem Wert der Form <span class="math inline">\(2^n\)</span> als <span class="math inline">\(n\)</span>-Fachen-Shift implementieren:</p>
+<p>In Assembly können wir also eine Multiplikation bzw. Division eines
+Registers mit einem Wert der Form <span
+class="math inline">\(2^n\)</span> als <span
+class="math inline">\(n\)</span>-Fachen-Shift implementieren:</p>
 <pre><code>shl rax, 1 ; rax = rax*2
 shl rax, 2 ; rax = rax*4
 
@@ -757,29 +915,49 @@ shr rax, 1 ; rax = rax/2 (ganzzahlig)
 shr rax, 2 ; rax = rax/4 (ganzzahlig)</code></pre>
 <h1 id="ssh-and-working-on-andorra">SSH and working on Andorra</h1>
 <h2 id="verbinden">Verbinden</h2>
-<p>Als Referenzsystem für unseren Code nutzen wir die Linux-Debian-Systeme an unserer Uni. Auf diese können wir über eine SSH Verbindung zugreifen.</p>
-<p>Um eine Verbindung mit den Andorra-System aufzunehmen öffnet ihr eine Command-Line und initiiert die Verbindung über SSH:</p>
+<p>Als Referenzsystem für unseren Code nutzen wir die
+Linux-Debian-Systeme an unserer Uni. Auf diese können wir über eine SSH
+Verbindung zugreifen.</p>
+<p>Um eine Verbindung mit den Andorra-System aufzunehmen öffnet ihr eine
+Command-Line und initiiert die Verbindung über SSH:</p>
 <pre><code>$ ssh ZEDAT_USER_NAME@andorra.imp.fu-berlin.de</code></pre>
-<p>Ähnlich funktioniert dies auch für die anderen Remote-Systeme der Uni: http://www.mi.fu-berlin.de/w/IT/ItServicesTerminalserver</p>
+<p>Ähnlich funktioniert dies auch für die anderen Remote-Systeme der
+Uni: http://www.mi.fu-berlin.de/w/IT/ItServicesTerminalserver</p>
 <h2 id="copying-files-sshscp">Copying files (SSH/SCP)</h2>
-<p>Um Dateien von eurem System auf die Remotesysteme der Universität zu bekommen kann man das auf SSH basierende SCP (Secure-Copy-Protocol) nutzen.</p>
+<p>Um Dateien von eurem System auf die Remotesysteme der Universität zu
+bekommen kann man das auf SSH basierende SCP (Secure-Copy-Protocol)
+nutzen.</p>
 <pre><code>$ scp PATH_TO_FILE ZEDAT_USER_NAME@andorra.imp.fu-berlin.de:DESTINATION_PATH</code></pre>
 <h1 id="how-to-compile">How-To-Compile:</h1>
-<p>Wir stellen euch zu (fast) jeder Assembly-Aufgabe einen C-Wrapper zur Verfügung. Keine Sorge, den müsst ihr noch nicht verstehen.</p>
-<p>Da Assembly eine menschenlesbare Version von Maschinen-Code ist muss diese zunächst Compiled/Übersetzt werden. Dazu erstellt ihr zunächst mit Hilfe von NASM eine Objekt-Datei (<code>.o</code>) aus eurem Assembly-Code:</p>
+<p>Wir stellen euch zu (fast) jeder Assembly-Aufgabe einen C-Wrapper zur
+Verfügung. Keine Sorge, den müsst ihr noch nicht verstehen.</p>
+<p>Da Assembly eine menschenlesbare Version von Maschinen-Code ist muss
+diese zunächst Compiled/Übersetzt werden. Dazu erstellt ihr zunächst mit
+Hilfe von NASM eine Objekt-Datei (<code>.o</code>) aus eurem
+Assembly-Code:</p>
 <pre><code>$ nasm -f elf64 -o PROGRAMM_NAME.o PROGRAMM_NAME.asm</code></pre>
-<p>Die Flag “-f elf64” teilt NASM mit, dass die Ausgabe für x64 Linux Übersetzt werden soll.</p>
-<p>Nun müsst ihr auch den C-Wrapper compilieren und eine weitere Objektdatei erzeugen:</p>
+<p>Die Flag “-f elf64” teilt NASM mit, dass die Ausgabe für x64 Linux
+Übersetzt werden soll.</p>
+<p>Nun müsst ihr auch den C-Wrapper compilieren und eine weitere
+Objektdatei erzeugen:</p>
 <pre><code>$ c99 -O2 -c -o PROGRAMM_NAME_wrapper.o PROGRAMM_NAME_wrapper.c</code></pre>
-<p>Die Flag <code>-O2</code> teilt unserem Compiler mit, dass wir die Optimierungsstufe 2 nutzen wollen (automatische Optimierung unseres C-Codes). Diese <em>müsst</em> ihr angeben, da dies Implikationen für euren Code hat.</p>
-<p>Anschließend müssen wir noch beide Objektdateien zu einer <strong>ausführbaren Datei</strong> verlinken:</p>
+<p>Die Flag <code>-O2</code> teilt unserem Compiler mit, dass wir die
+Optimierungsstufe 2 nutzen wollen (automatische Optimierung unseres
+C-Codes). Diese <em>müsst</em> ihr angeben, da dies Implikationen für
+euren Code hat.</p>
+<p>Anschließend müssen wir noch beide Objektdateien zu einer
+<strong>ausführbaren Datei</strong> verlinken:</p>
 <pre><code>$ c99 -o PROGRAMM_NAME PROGRAMM_NAME_wrapper.o PROGRAMM_NAME.o</code></pre>
-<p>Abschließend solltet ihr eine Datei mit dem Namen “PROGRAMM_NAME” besitzen. Diese könnt ihr wie folgt ausführen:</p>
+<p>Abschließend solltet ihr eine Datei mit dem Namen “PROGRAMM_NAME”
+besitzen. Diese könnt ihr wie folgt ausführen:</p>
 <pre><code>$ ./PROGRAMM_NAMME [parameter 1] [parameter 2] [parameter 3] ...</code></pre>
 <p>Alternativ könnt ihr auch einfach die gegebene MAKEFILE nutzen</p>
 <pre><code>$ make</code></pre>
 <h1 id="debugging-mit-gdb">Debugging mit GDB:</h1>
-<p>Um Einblick in die Ausführung des ASM-Codes zu bekommen kann man <code>gdb</code> verwenden. Hierzu findet ihr eine kleine Zusammenfassung von Befehlen zur Ausführung des <code>gdb</code> mit einer Terminal “UI”:</p>
+<p>Um Einblick in die Ausführung des ASM-Codes zu bekommen kann man
+<code>gdb</code> verwenden. Hierzu findet ihr eine kleine
+Zusammenfassung von Befehlen zur Ausführung des <code>gdb</code> mit
+einer Terminal “UI”:</p>
 <pre><code>$ gdb PROGRAMM_NAME                 Lade deinen code in gdb
 gdb&gt; break SOME_LABEL_IN_YOUR_CODE  Setze einen &quot;Breakpoint&quot; bei dem dein Programm hält
 gdb&gt; tui enable                     Aktiviere die UI

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -225,22 +225,22 @@ manuell vor dem Aufruf sichern.</p>
 <td>reg1 = reg1 &gt;&gt; <code>cl</code>/imm</td>
 </tr>
 <tr class="even">
-<td><a href="#neg-reg1">neg</a></td>
-<td>reg1</td>
-<td></td>
-<td>reg1 = -reg1 (2er Komplement)</td>
-</tr>
-<tr class="odd">
 <td><a href="#add-reg1-value--add-reg1-reg2">add</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 = reg1 + reg2/imm</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#sub-reg1-value--sub-reg1-reg2">sub</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 = reg1 - reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#neg-reg1">neg</a></td>
+<td>reg1</td>
+<td></td>
+<td>reg1 = -reg1 (2er Komplement)</td>
 </tr>
 <tr class="odd">
 <td><a href="#mul-reg1">mul</a></td>
@@ -417,11 +417,6 @@ class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <pre><code>ror rax, rdx
 ror rax, 1</code></pre>
 <h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
-<h3 id="neg-reg1">neg reg1:</h3>
-<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
-Komplement).</p>
-<p>Beispiel:</p>
-<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
 <h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
 reg2:</h3>
 <p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
@@ -435,6 +430,11 @@ reg2:</h3>
 <p>Beispiele:</p>
 <pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
 sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
+<h3 id="neg-reg1">neg reg1:</h3>
+<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
+Komplement).</p>
+<p>Beispiel:</p>
+<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
 <h3 id="mul-reg1">mul reg1:</h3>
 <p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
 angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -665,10 +665,12 @@ durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
 (ganzzahlige Division) und rdx (Rest) gespeichert</p>
 <p>Beispiel:</p>
 <pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
-<p>ACHTUNG: Prüfe vor der Division, ob der Wert, der sich in rdx
-befindet, korrekt ist. Dort könnte sich 1. ein Wert befinden, der nichts
-mit der gewollten Rechnung zu tun hat und 2. ein Wert drin befinden der
-nach der Division erhalten bleiben sollte.</p>
+<p>ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax. Also
+aufpassen, dass nicht ungewollt noch was in rdx steht. Übliches
+Muster:</p>
+<pre><code>mov rsi, 3
+mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
+div rsi    ; Dividiere rax durch 3</code></pre>
 <h3 id="imul-reg-value-1-und-idiv-reg-value-1">imul reg (value 1) und
 idiv reg (value 1):</h3>
 <p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -683,19 +683,26 @@ class="math inline">\(b\)</span> mit einer Zahl der Form <span
 class="math inline">\(b^n\)</span> kann als einfache "Verschiebung" um
 <span class="math inline">\(n\)</span> Stellen betrachtet werden. Gucken
 wir uns dies zuerst im Dezimalsystem mit 10-er Potenzen an:</p>
-<p>\begin{align*} 12 \cdot 10^1 &amp;= 12 \cdot 10 &amp;&amp;= 120 \ 12
-\cdot 10^2 &amp;= 12 \cdot 100 &amp;&amp;= 1200 \ 12 \cdot 10^3 &amp;=
-12 \cdot 1000 &amp;&amp;= 12000 \end{align*}</p>
-<p>\begin{align*} 12 \div 10^1 &amp;= 12 \div 10 &amp;&amp;= 1.2 \ 12
-\div 10^2 &amp;= 12 \div 100 &amp;&amp;= 0.12 \ 12 \div 10^3 &amp;= 12
-\div 1000 &amp;&amp;= 0.012 \end{align*}</p>
+<p><span class="math display">\[\begin{align*}
+12 \cdot 10^1 &amp;= 12 \cdot 10   &amp;&amp;= 120 \\
+12 \cdot 10^2 &amp;= 12 \cdot 100  &amp;&amp;= 1200 \\
+12 \cdot 10^3 &amp;= 12 \cdot 1000 &amp;&amp;= 12000
+\end{align*}\]</span></p>
+<p><span class="math display">\[\begin{align*}
+12 \div 10^1 &amp;= 12 \div 10   &amp;&amp;= 1.2 \\
+12 \div 10^2 &amp;= 12 \div 100  &amp;&amp;= 0.12 \\
+12 \div 10^3 &amp;= 12 \div 1000 &amp;&amp;= 0.012
+\end{align*}\]</span></p>
 <p>Im Binärsystem gilt dieses Prinzip natürlich auch:</p>
-<p>\begin{align*} 0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10}
-&amp;&amp;= 0110_2 \ 0011_2 \cdot 2_{10}^2 &amp;= 0011_2 \cdot 4_{10}
-&amp;&amp;= 1100_2 \end{align*}</p>
-<p>\begin{align*} 0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10}
-&amp;&amp;= 0001(.1000)<em>2 \ 0011_2 \div 2</em>{10}^2 &amp;= 0011_2
-\div 4_{10} &amp;&amp;= 0000(.1100)_2 \end{align*}</p>
+<p><span class="math display">\[\begin{align*}
+0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10} &amp;&amp;= 0110_2 \\
+0011_2 \cdot 2_{10}^2 &amp;= 0011_2 \cdot 4_{10} &amp;&amp;= 1100_2
+\end{align*}\]</span></p>
+<p><span class="math display">\[\begin{align*}
+0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10} &amp;&amp;= 0001(.1000)_2
+\\
+0011_2 \div 2_{10}^2 &amp;= 0011_2 \div 4_{10} &amp;&amp;= 0000(.1100)_2
+\end{align*}\]</span></p>
 <p>Hinweise:</p>
 <ol type="1">
 <li>Wir geben mit den Subscripts die Basis der Zahlendarstellung

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -512,58 +512,6 @@ weiteres Register.</p>
 <p>Beispiel:</p>
 <pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
-<h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1),
-value / shl reg (value 1), cl</h3>
-<p>Definition: Shifte den Wert des Registers um <span
-class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
-“rausgeschoben” werden gehen verloren</p>
-<p>Beispiel:</p>
-<pre><code>shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
-shl rax, 1   ; Verschiebe alle Bits</code></pre>
-<p>Beispiel under the hood:</p>
-<pre><code>rax = 1100 0011
-
-shl rax, 1
-
-=&gt; rax = 1000 0110</code></pre>
-<p>ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register
-<code>cl</code> als Registerverschiebungswert nehmen! Dies ist dadurch
-begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
-des Count-Registers (<code>cl</code>) angelegt wurde für
-Verschiebungen.</p>
-<h3 id="shr-reg-value-1-value-shr-reg-value-1-cl">shr reg (value 1),
-value / shr reg (value 1), cl</h3>
-<p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
-Also analog zu <code>shl</code>.</p>
-<p>Beispiel:</p>
-<pre><code>shr rax, cl
-shr rax, 1</code></pre>
-<p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> können
-nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
-Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
-Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
-<h3 id="rol-reg-value-1-value-rol-reg-value-1-reg-value-2">rol reg
-(value 1), value / rol reg (value 1), reg (value 2)</h3>
-<p>Definition: Rotiere die Werte um <span
-class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
-gehen hier die Bits die nach links raus geschoben werden nicht verloren,
-sondern werden rechts hinzugefügt.</p>
-<p>Beispiel:</p>
-<pre><code>rol rax, rdx
-rol rax, 1</code></pre>
-<p>Beispiel under the hood:</p>
-<pre><code>rax = 1100 0100
-
-rol rax, 1
-=&gt; rax = 1000 1001</code></pre>
-<h3 id="ror-reg-value-1-value-ror-reg-value-1-reg-value-2">ror reg
-(value 1), value / ror reg (value 1), reg (value 2)</h3>
-<p>Definition: Rotiere die Werte um <span
-class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
-<code>rol</code></p>
-<p>Beispiel:</p>
-<pre><code>ror rax, rdx
-ror rax, 1</code></pre>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
 <h3 id="and-reg-value-1-value-and-reg-value-1-reg-value-2">and reg
 (value 1), value / and reg (value 1), reg (value 2)</h3>
@@ -621,6 +569,58 @@ xor rdx, 0x8f
 1000 1111
 ---------
 0000 1011 = rdx</code></pre>
+<h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1),
+value / shl reg (value 1), cl</h3>
+<p>Definition: Shifte den Wert des Registers um <span
+class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
+“rausgeschoben” werden gehen verloren</p>
+<p>Beispiel:</p>
+<pre><code>shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
+shl rax, 1   ; Verschiebe alle Bits</code></pre>
+<p>Beispiel under the hood:</p>
+<pre><code>rax = 1100 0011
+
+shl rax, 1
+
+=&gt; rax = 1000 0110</code></pre>
+<p>ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register
+<code>cl</code> als Registerverschiebungswert nehmen! Dies ist dadurch
+begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
+des Count-Registers (<code>cl</code>) angelegt wurde für
+Verschiebungen.</p>
+<h3 id="shr-reg-value-1-value-shr-reg-value-1-cl">shr reg (value 1),
+value / shr reg (value 1), cl</h3>
+<p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
+Also analog zu <code>shl</code>.</p>
+<p>Beispiel:</p>
+<pre><code>shr rax, cl
+shr rax, 1</code></pre>
+<p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> können
+nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
+Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
+Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
+<h3 id="rol-reg-value-1-value-rol-reg-value-1-reg-value-2">rol reg
+(value 1), value / rol reg (value 1), reg (value 2)</h3>
+<p>Definition: Rotiere die Werte um <span
+class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
+gehen hier die Bits die nach links raus geschoben werden nicht verloren,
+sondern werden rechts hinzugefügt.</p>
+<p>Beispiel:</p>
+<pre><code>rol rax, rdx
+rol rax, 1</code></pre>
+<p>Beispiel under the hood:</p>
+<pre><code>rax = 1100 0100
+
+rol rax, 1
+=&gt; rax = 1000 1001</code></pre>
+<h3 id="ror-reg-value-1-value-ror-reg-value-1-reg-value-2">ror reg
+(value 1), value / ror reg (value 1), reg (value 2)</h3>
+<p>Definition: Rotiere die Werte um <span
+class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
+<code>rol</code></p>
+<p>Beispiel:</p>
+<pre><code>ror rax, rdx
+ror rax, 1</code></pre>
 <h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
 <h3 id="neg-reg-value-1">neg reg (value 1):</h3>
 <p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -20,6 +20,70 @@
       margin: 0 0.8em 0.2em -1.6em;
       vertical-align: middle;
     }
+    /* CSS for syntax highlighting */
+    pre > code.sourceCode { white-space: pre; position: relative; }
+    pre > code.sourceCode > span { line-height: 1.25; }
+    pre > code.sourceCode > span:empty { height: 1.2em; }
+    .sourceCode { overflow: visible; }
+    code.sourceCode > span { color: inherit; text-decoration: inherit; }
+    div.sourceCode { margin: 1em 0; }
+    pre.sourceCode { margin: 0; }
+    @media screen {
+    div.sourceCode { overflow: auto; }
+    }
+    @media print {
+    pre > code.sourceCode { white-space: pre-wrap; }
+    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+    }
+    pre.numberSource code
+      { counter-reset: source-line 0; }
+    pre.numberSource code > span
+      { position: relative; left: -4em; counter-increment: source-line; }
+    pre.numberSource code > span > a:first-child::before
+      { content: counter(source-line);
+        position: relative; left: -1em; text-align: right; vertical-align: baseline;
+        border: none; display: inline-block;
+        -webkit-touch-callout: none; -webkit-user-select: none;
+        -khtml-user-select: none; -moz-user-select: none;
+        -ms-user-select: none; user-select: none;
+        padding: 0 4px; width: 4em;
+        color: #aaaaaa;
+      }
+    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+    div.sourceCode
+      {   }
+    @media screen {
+    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+    }
+    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+    code span.at { color: #7d9029; } /* Attribute */
+    code span.bn { color: #40a070; } /* BaseN */
+    code span.bu { color: #008000; } /* BuiltIn */
+    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+    code span.ch { color: #4070a0; } /* Char */
+    code span.cn { color: #880000; } /* Constant */
+    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+    code span.dt { color: #902000; } /* DataType */
+    code span.dv { color: #40a070; } /* DecVal */
+    code span.er { color: #ff0000; font-weight: bold; } /* Error */
+    code span.ex { } /* Extension */
+    code span.fl { color: #40a070; } /* Float */
+    code span.fu { color: #06287e; } /* Function */
+    code span.im { color: #008000; font-weight: bold; } /* Import */
+    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+    code span.op { color: #666666; } /* Operator */
+    code span.ot { color: #007020; } /* Other */
+    code span.pp { color: #bc7a00; } /* Preprocessor */
+    code span.sc { color: #4070a0; } /* SpecialChar */
+    code span.ss { color: #bb6688; } /* SpecialString */
+    code span.st { color: #4070a0; } /* String */
+    code span.va { color: #19177c; } /* Variable */
+    code span.vs { color: #4070a0; } /* VerbatimString */
+    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
   </style>
   <link rel="stylesheet" href="styles/style.css" />
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
@@ -319,27 +383,31 @@ reg (to), reg (from):</h3>
 <p>Definition: Verschiebe ein Wert bzw. den Wert eines Registers in ein
 weiteres Register.</p>
 <p>Beispiel:</p>
-<pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
-mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
+<div class="sourceCode" id="cb1"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span> <span class="co">; Verschiebe Wert von rdx in rax (ergo rax = rdx)</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">2</span>   <span class="co">; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</span></span></code></pre></div>
 <h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
 <h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
 reg2:</h3>
 <p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
 Wert eines anderen Registers.</p>
 <p>Beispiel:</p>
-<pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
-add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
+<div class="sourceCode" id="cb2"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">add</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span> <span class="co">; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="kw">add</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">2</span>   <span class="co">; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</span></span></code></pre></div>
 <h3 id="sub-reg1-value--sub-reg1-reg2">sub reg1, value / sub reg1,
 reg2:</h3>
 <p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
 <p>Beispiele:</p>
-<pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
-sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
+<div class="sourceCode" id="cb3"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="kw">sub</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span> <span class="co">; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="kw">sub</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">2</span>   <span class="co">; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</span></span></code></pre></div>
 <h3 id="neg-reg1">neg reg1:</h3>
 <p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
 Komplement).</p>
 <p>Beispiel:</p>
-<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
+<div class="sourceCode" id="cb4"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">neg</span> <span class="kw">rsi</span> <span class="co">; Negiere den Wert in rsi</span></span></code></pre></div>
 <h3 id="mul-reg1">mul reg1:</h3>
 <p>Definition: Multipliziere den Wert in Register <code>rax</code> mit
 dem Wert des angegebenen Registers. Das Ergebnis wird in die
@@ -347,26 +415,30 @@ dem Wert des angegebenen Registers. Das Ergebnis wird in die
 <code>rdx</code> gespeichert (<code>rdx</code>, falls ein Überlauf der
 Zahl in <code>rax</code> passiert)</p>
 <p>Beispiel:</p>
-<pre><code>mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</code></pre>
+<div class="sourceCode" id="cb5"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mul</span> <span class="kw">rsi</span> <span class="co">; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</span></span></code></pre></div>
 <p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden.
 Falls man das Register <code>rax</code> mit einem bestimmten Wert
 multiplizieren möchte muss man diesen vorher in ein Register
 verschieben:</p>
-<pre><code>mov rsi, 3
-mul rsi    ; Multipliziere rax mit 3</code></pre>
+<div class="sourceCode" id="cb6"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">3</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="kw">mul</span> <span class="kw">rsi</span>    <span class="co">; Multipliziere rax mit 3</span></span></code></pre></div>
 <h3 id="div-reg1">div reg1:</h3>
 <p>Definition: Dividiere den Wert aus <code>rdx:rax</code>
 (<code>rdx</code> konkateniert mit <code>rax</code>) durch den Wert aus
 dem angegebenen Register. Ergebnis wird in <code>rax</code> (ganzzahlige
 Division) und <code>rdx</code> (Rest) gespeichert</p>
 <p>Beispiel:</p>
-<pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
+<div class="sourceCode" id="cb7"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="kw">div</span> <span class="kw">rsi</span> <span class="co">; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</span></span></code></pre></div>
 <p>ACHTUNG: Der Divisor ist nicht nur <code>rax</code>, sondern
 <code>rdx:rax</code>. Also aufpassen, dass nicht ungewollt noch was in
 <code>rdx</code> steht. Übliches Muster:</p>
-<pre><code>mov rsi, 3
-mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
-div rsi    ; Dividiere rax durch 3</code></pre>
+<div class="sourceCode" id="cb8"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">3</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rdx</span><span class="op">,</span> <span class="dv">0</span> <span class="co">; Sicherstellen, dass obere 64 Bit des Divisors 0 sind</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="kw">div</span> <span class="kw">rsi</span>    <span class="co">; Dividiere rax durch 3</span></span></code></pre></div>
 <h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
 <p>Definition: Analog zu <code>mul</code>/<code>div</code>, aber mit
 signed Zahlen (d.h. Zahlen mit Vorzeichen)</p>
@@ -378,8 +450,9 @@ class="math inline">\(\land\)</span>) mit dem Wert des zweiten
 Parameters auf den Wert des ersten Registers an und speichert das
 Ergebnis im ersten Register.</p>
 <p>Beispiel:</p>
-<pre><code>and rax, rsi ; Verunde den Wert aus rax mit dem Wert aus rsi
-and rax, 0x1 ; Verunde den Wert aus rax mit dem Wert 0x1 (Hexadezimal-Zahl)</code></pre>
+<div class="sourceCode" id="cb9"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="kw">and</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rsi</span> <span class="co">; Verunde den Wert aus rax mit dem Wert aus rsi</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="kw">and</span> <span class="kw">rax</span><span class="op">,</span> <span class="bn">0x1</span> <span class="co">; Verunde den Wert aus rax mit dem Wert 0x1 (Hexadezimal-Zahl)</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rax = 0101 1101
 rsi = 1101 1011
@@ -396,8 +469,9 @@ class="math inline">\(\lor\)</span>) mit dem Wert des zweiten Parameters
 auf das erste Register an und speichert das Ergebnis im ersten
 Register.</p>
 <p>Beispiel:</p>
-<pre><code>or rax, rsi ; Veroder den Wert aus rax mit dem Wert aus rsi
-or rdx, 0xf ; Veroder den Wert aus rdx mit dem Wert 0xf (Binär = 1111)</code></pre>
+<div class="sourceCode" id="cb11"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="kw">or</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rsi</span> <span class="co">; Veroder den Wert aus rax mit dem Wert aus rsi</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="kw">or</span> <span class="kw">rdx</span><span class="op">,</span> <span class="bn">0xf</span> <span class="co">; Veroder den Wert aus rdx mit dem Wert 0xf (Binär = 1111)</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rdx = 0011 1101
 0xf = 0000 1101
@@ -414,8 +488,9 @@ reg2:</h3>
 class="math inline">\(\oplus\)</span>) mit dem Wert des zweiten
 Parameters auf den Wert des ersten Registers an.</p>
 <p>Beispiel:</p>
-<pre><code>xor rax, rsi  ; Wendet XOR auf den Wert von rax mit dem Wert von rsi an
-xor rdx, 0x8f ; Wendet XOR auf den Wert von rdx mit 0x8f (Binär = 1000 1111) an</code></pre>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">xor</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rsi</span>  <span class="co">; Wendet XOR auf den Wert von rax mit dem Wert von rsi an</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="kw">xor</span> <span class="kw">rdx</span><span class="op">,</span> <span class="bn">0x8f</span> <span class="co">; Wendet XOR auf den Wert von rdx mit 0x8f (Binär = 1000 1111) an</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rdx  = 0011 1011
 0xff = 1000 1111
@@ -430,16 +505,18 @@ xor rdx, 0x8f
 <p>Definition: Invertiert den Wert im ersten Register (alle 0en werden
 zu 1en und umgekehrt).</p>
 <p>Beispiel:</p>
-<pre><code>; rdx = 0011 1011
-neg rdx
-; rdx = 1100 0100</code></pre>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="co">; rdx = 0011 1011</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="kw">neg</span> <span class="kw">rdx</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="co">; rdx = 1100 0100</span></span></code></pre></div>
 <h3 id="shl-reg1-value--shl-reg1-cl">shl reg1, value / shl reg1, cl</h3>
 <p>Definition: Shifte den Wert des Registers um <span
 class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
 "rausgeschoben" werden gehen verloren</p>
 <p>Beispiel:</p>
-<pre><code>shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
-shl rax, 1   ; Verschiebe alle Bits</code></pre>
+<div class="sourceCode" id="cb16"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">shl</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">cl</span> <span class="co">; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a><span class="kw">shl</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span>   <span class="co">; Verschiebe alle Bits</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rax = 1100 0011
 
@@ -455,8 +532,9 @@ angelegt wurde für Verschiebungen.</p>
 <p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
 Also analog zu <code>shl</code>.</p>
 <p>Beispiel:</p>
-<pre><code>shr rax, cl
-shr rax, 1</code></pre>
+<div class="sourceCode" id="cb18"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="kw">shr</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">cl</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="kw">shr</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span></span></code></pre></div>
 <p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> können
 nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
 Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
@@ -468,8 +546,9 @@ class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
 gehen hier die Bits die nach links raus geschoben werden nicht verloren,
 sondern werden rechts hinzugefügt.</p>
 <p>Beispiel:</p>
-<pre><code>rol rax, rdx
-rol rax, 1</code></pre>
+<div class="sourceCode" id="cb19"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="kw">rol</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="kw">rol</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rax = 1100 0100
 
@@ -481,8 +560,9 @@ reg2</h3>
 class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <code>rol</code></p>
 <p>Beispiel:</p>
-<pre><code>ror rax, rdx
-ror rax, 1</code></pre>
+<div class="sourceCode" id="cb21"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="kw">ror</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="kw">ror</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span></span></code></pre></div>
 <h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und
 Bedinge Sprünge:</h2>
 <h3 id="cmp-reg1-value--cmp-reg1-reg2">cmp reg1, value / cmp reg1,
@@ -491,20 +571,22 @@ reg2:</h3>
 eines weiteren Registers. Diese Operation setzt Bits im Flag-Register
 die später für Bedingte-Sprünge verwendet werden könnten</p>
 <p>Beispiel:</p>
-<pre><code>cmp rax, rsi ; Vergleiche rax mit dem Wert aus rsi
-cmp rax, 2   ; Vergleiche rax mit dem Wert 2</code></pre>
+<div class="sourceCode" id="cb22"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="kw">cmp</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rsi</span> <span class="co">; Vergleiche rax mit dem Wert aus rsi</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a><span class="kw">cmp</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">2</span>   <span class="co">; Vergleiche rax mit dem Wert 2</span></span></code></pre></div>
 <h3 id="jmp-some_label">jmp some_label:</h3>
 <p>Definition: Setze den Programm Counter (PC, bzw. <code>rip</code>)
 auf die Adresse des angegebenen Labels (<code>some_label</code>). An
 Stelle eines Labels kann auch direkt eine Zahl als Adresse genutzt
 werden (<code>jmp 100</code>).</p>
 <p>Beispiel:</p>
-<pre><code>; [...]
-jmp .some_label
-; [...]
-
-.some_label:
-; [Do something]</code></pre>
+<div class="sourceCode" id="cb23"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="co">; [...]</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a><span class="cf">jmp</span> <span class="fu">.some_label</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a><span class="co">; [...]</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a><span class="fu">.some_label:</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a><span class="co">; [Do something]</span></span></code></pre></div>
 <h3 id="jx-some_label">j<em>X</em> some_label:</h3>
 <p>(<em>X</em> wird durch eine von vielen Bezeichnungen ersetzt:
 <code>je</code>, <code>jne</code>, ...)</p>
@@ -572,14 +654,15 @@ oben nur mit equal</td>
 </tbody>
 </table>
 <p>Beispiele:</p>
-<pre><code>; [...]
-cmp rax, 2
-jl .some_label
-; execute here if rax &gt;= 2
-; [...]
-
-.some_label:
-; execute here if rax &lt; 2</code></pre>
+<div class="sourceCode" id="cb24"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="co">; [...]</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a><span class="kw">cmp</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">2</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a><span class="cf">jl</span> <span class="fu">.some_label</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a><span class="co">; execute here if rax &gt;= 2</span></span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a><span class="co">; [...]</span></span>
+<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a><span class="fu">.some_label:</span></span>
+<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a><span class="co">; execute here if rax &lt; 2</span></span></code></pre></div>
 <h3 id="test-reg1-value--test-reg1-reg2">test reg1, value / test reg1,
 reg2:</h3>
 <p>Definition: Führt ein logisches UND (<span
@@ -620,17 +703,19 @@ Beginn des Funktionsaufrufs!</p>
 <code>push</code>-Befehl. Dieser legt dann den Wert des angegebenen
 Registers auf den Stack ab und aktualisiert den Stack-Pointer.</p>
 <p>Beispiel:</p>
-<pre><code>push rax
-push esi
-push cl</code></pre>
+<div class="sourceCode" id="cb25"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="kw">push</span> <span class="kw">rax</span></span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a><span class="kw">push</span> <span class="kw">esi</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a><span class="kw">push</span> <span class="kw">cl</span></span></code></pre></div>
 <h3 id="pop-reg">pop reg:</h3>
 <p>Definition: Um Daten vom Stack wieder zu nehmen nutzt man den
 <code>pop</code>-Befehl. Dieser lädt das Datum welches zuletzt auf den
 Stack gelegt wurde und speichert es in das jeweilige Register.</p>
 <p>Beispiel:</p>
-<pre><code>pop cl
-pop esi
-pop rax</code></pre>
+<div class="sourceCode" id="cb26"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="kw">pop</span> <span class="kw">cl</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a><span class="kw">pop</span> <span class="kw">esi</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a><span class="kw">pop</span> <span class="kw">rax</span></span></code></pre></div>
 <p>WICHTIG: Es muss in umgekehrter Reigenfolge gepoppt werden wie die
 Elemente gepusht wurde. Dies ist der Fall wegen der LIFO-Struktur des
 Stacks!</p>
@@ -647,30 +732,32 @@ zur jeweiligen Adresse durchgeführt wird.</p>
 dass ihr die Calling-Convention beachtet (bspw. Eingaberegister füllen
 oder jeweilige Register sichern)</p>
 <p>Beispiel:</p>
-<pre><code>some_function:
-    ...
-    call some_other_function
-    ; ret der subroutine macht hier weiter
-    ...
-
-some_other_function:
-    ...
-    ret</code></pre>
+<div class="sourceCode" id="cb27"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">some_function:</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">call</span> some_other_function</span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>    <span class="co">; ret der subroutine macht hier weiter</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a><span class="fu">some_other_function:</span></span>
+<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">ret</span></span></code></pre></div>
 <h1 id="assembly-tricks">Assembly-Tricks:</h1>
 <h3 id="ein-register-auf-0-setzen-clean-oder-bereinigen">Ein Register
 auf 0 setzen ("clean" oder "bereinigen")</h3>
 <p>Um den Wert eines Registers auf 0 zu setzen könnt ihr einfach die
 Zahl 0 in das jeweilige Register setzen:</p>
-<pre><code>mov rax, 0 ; Setze rax = 0</code></pre>
+<div class="sourceCode" id="cb28"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">0</span> <span class="co">; Setze rax = 0</span></span></code></pre></div>
 <p>Optional hierzu könnt ihr die <code>xor</code>-Instruktion nutzen. Da
 XOR ein gegebenen Bit auf 0 setzt, gdw. beide Register-Einträge 0 sind,
 ODER beide Registereinträge 1 sind folgt daraus, dass ein XOR mit dem
 selben Wert das jeweilige Register auf 0 setzen wird. Dies hat also den
 selben Effekt wie ein <code>mov</code> Befehl und <em>kann</em> unter
 Umständen effizienter sein (konkret ist die Codierungslänge kürzer).</p>
-<pre><code>xor rax, rax ; Setze rax = 0
-
-e.g rax = 1101 1111
+<div class="sourceCode" id="cb29"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="kw">xor</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rax</span> <span class="co">; Setze rax = 0</span></span></code></pre></div>
+<pre><code>e.g rax = 1101 1111
 
 xor rax, rax
 =&gt;
@@ -718,11 +805,12 @@ ganzzahlige Division möglich.</li>
 Registers mit einem Wert der Form <span
 class="math inline">\(2^n\)</span> als <span
 class="math inline">\(n\)</span>-Fachen-Shift implementieren:</p>
-<pre><code>shl rax, 1 ; rax = rax*2
-shl rax, 2 ; rax = rax*4
-
-shr rax, 1 ; rax = rax/2 (ganzzahlig)
-shr rax, 2 ; rax = rax/4 (ganzzahlig)</code></pre>
+<div class="sourceCode" id="cb31"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">shl</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span> <span class="co">; rax = rax*2</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="kw">shl</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">2</span> <span class="co">; rax = rax*4</span></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a><span class="kw">shr</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span> <span class="co">; rax = rax/2 (ganzzahlig)</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="kw">shr</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">2</span> <span class="co">; rax = rax/4 (ganzzahlig)</span></span></code></pre></div>
 <h1 id="ssh-and-working-on-andorra">SSH and working on Andorra</h1>
 <h2 id="verbinden">Verbinden</h2>
 <p>Als Referenzsystem für unseren Code nutzen wir die

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -23,7 +23,7 @@
   </style>
   <link rel="stylesheet" href="styles/style.css" />
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script src="/usr/share/javascript/mathjax/MathJax.js"
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js"
   type="text/javascript"></script>
 </head>
 <body>

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -341,32 +341,35 @@ Komplement).</p>
 <p>Beispiel:</p>
 <pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
 <h3 id="mul-reg1">mul reg1:</h3>
-<p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
-angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>
-Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in
-rax passiert)</p>
+<p>Definition: Multipliziere den Wert in Register <code>rax</code> mit
+dem Wert des angegebenen Registers. Das Ergebnis wird in die
+<strong>beiden (!!!)</strong> Registern <code>rax</code> und
+<code>rdx</code> gespeichert (<code>rdx</code>, falls ein Überlauf der
+Zahl in <code>rax</code> passiert)</p>
 <p>Beispiel:</p>
 <pre><code>mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</code></pre>
 <p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden.
-Falls man das Register rax mit einem bestimmten Wert multiplizieren
-möchte muss man diesen vorher in ein Register verschieben:</p>
+Falls man das Register <code>rax</code> mit einem bestimmten Wert
+multiplizieren möchte muss man diesen vorher in ein Register
+verschieben:</p>
 <pre><code>mov rsi, 3
 mul rsi    ; Multipliziere rax mit 3</code></pre>
 <h3 id="div-reg1">div reg1:</h3>
-<p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax)
-durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
-(ganzzahlige Division) und rdx (Rest) gespeichert</p>
+<p>Definition: Dividiere den Wert aus <code>rdx:rax</code>
+(<code>rdx</code> konkateniert mit <code>rax</code>) durch den Wert aus
+dem angegebenen Register. Ergebnis wird in <code>rax</code> (ganzzahlige
+Division) und <code>rdx</code> (Rest) gespeichert</p>
 <p>Beispiel:</p>
 <pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
-<p>ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax. Also
-aufpassen, dass nicht ungewollt noch was in rdx steht. Übliches
-Muster:</p>
+<p>ACHTUNG: Der Divisor ist nicht nur <code>rax</code>, sondern
+<code>rdx:rax</code>. Also aufpassen, dass nicht ungewollt noch was in
+<code>rdx</code> steht. Übliches Muster:</p>
 <pre><code>mov rsi, 3
 mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
 div rsi    ; Dividiere rax durch 3</code></pre>
 <h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
-<p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen
-mit Vorzeichen)</p>
+<p>Definition: Analog zu <code>mul</code>/<code>div</code>, aber mit
+signed Zahlen (d.h. Zahlen mit Vorzeichen)</p>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
 <h3 id="and-reg1-value--and-reg1-reg2">and reg1, value / and reg1,
 reg2</h3>
@@ -443,11 +446,11 @@ shl rax, 1   ; Verschiebe alle Bits</code></pre>
 shl rax, 1
 
 =&gt; rax = 1000 0110</code></pre>
-<p>ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register
-<code>cl</code> als Registerverschiebungswert nehmen! Dies ist dadurch
-begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
-des Count-Registers (<code>cl</code>) angelegt wurde für
-Verschiebungen.</p>
+<p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> nutzen
+können nur das Register <code>cl</code> als Registerverschiebungswert
+nehmen! Dies ist dadurch begründet, dass bei der Entwicklung eines
+x86-Chips nur eine Verbindung des Count-Registers (<code>cl</code>)
+angelegt wurde für Verschiebungen.</p>
 <h3 id="shr-reg1-value--shr-reg1-cl">shr reg1, value / shr reg1, cl</h3>
 <p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
 Also analog zu <code>shl</code>.</p>
@@ -609,9 +612,9 @@ den Beginn des Stacks währenddessen der Stack-Pointer auf die nächste
 belegte Adresse zeigt. Der Stack wächst, wenn <code>rsp</code> kleiner
 wird. Daher "wächst" der Stack nach unten. (Der Stack ist "full
 descending".)</p>
-<p>WICHTIG: nach dem Funktionsaufruf (also vor dem ret Befehl) muss der
-Stack-Pointer wieder auf der selben Stelle sein wie zu Beginn des
-Funktionsaufrufs!</p>
+<p>WICHTIG: nach dem Funktionsaufruf (also vor dem <code>ret</code>
+Befehl) muss der Stack-Pointer wieder auf der selben Stelle sein wie zu
+Beginn des Funktionsaufrufs!</p>
 <h3 id="push-reg">push reg:</h3>
 <p>Definition: Um Daten auf den Stack zu legen nutzt man den
 <code>push</code>-Befehl. Dieser legt dann den Wert des angegebenen

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -697,10 +697,9 @@ jmp .some_label
 
 .some_label:
 ; [Do something]</code></pre>
-<h3
-id="jl-some_label-jb-some_label-jg-some_label-ja-some_label-je-some_label-jne-some_label">jl
-some_label / jb some_label / jg some_label / ja some_label / je
-some_label / jne some_label …</h3>
+<h3 id="jx-some_label">j<em>X</em> some_label:</h3>
+<p>(<em>X</em> wird durch eine von vielen Bezeichnungen ersetzt:
+<code>je</code>, <code>jne</code>, …)</p>
 <p>Definition: Springe, wenn bestimmte Bits im Flag-Register gesetzt
 sind. Dies wird in der Regel in Kombination mit einer
 Vergleich-Operation genutzt, um diese Bits zu setzen.</p>

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -34,401 +34,67 @@
 <h1 id="register">Register</h1>
 <table style="background-color: #f8f9fa;color: #202122;margin: 1em 0;border: 1px solid #a2a9b1;border-collapse: collapse;">
 <tbody>
-<tr>
-<th>
-Register
-</th>
-<th style="width: 12%;" colspan="8">
-Accumulator
-</th>
-<th style="width: 12%;" colspan="8">
-Counter
-</th>
-<th style="width: 12%;" colspan="8">
-Data
-</th>
-<th style="width: 12%;" colspan="8">
-Base
-</th>
-<th style="width: 12%;" colspan="8">
-Stack Pointer
-</th>
-<th style="width: 12%;" colspan="8">
-Stack Base Pointer
-</th>
-<th style="width: 12%;" colspan="8">
-Source
-</th>
-<th style="width: 12%;" colspan="8">
-Destination
-</th>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-64-bit
-</th>
-<td colspan="8">
-rax
-</td>
-<td colspan="8">
-rcx
-</td>
-<td colspan="8">
-rdx
-</td>
-<td colspan="8">
-rbx
-</td>
-<td colspan="8">
-rsp
-</td>
-<td colspan="8">
-rbp
-</td>
-<td colspan="8">
-rsi
-</td>
-<td colspan="8">
-rdi
-</td>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-32-bit
-</th>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-eax
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-ecx
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-edx
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-ebx
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-esp
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-ebp
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-esi
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-edi
-</td>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-16-bit
-</th>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-ax
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-cx
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-dx
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-bx
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-sp
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-bp
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-si
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-di
-</td>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-8-bit
-</th>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 1.5%;" colspan="1">
-ah
-</td>
-<td style="width: 1.5%;" colspan="1">
-al
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 1.5%;" colspan="1">
-ch
-</td>
-<td style="width: 1.5%;" colspan="1">
-cl
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 1.5%;" colspan="1">
-dh
-</td>
-<td style="width: 1.5%;" colspan="1">
-dl
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 1.5%;" colspan="1">
-bh
-</td>
-<td style="width: 1.5%;" colspan="1">
-bl
-</td>
-<td style="width: 9%;" colspan="7">
-</td>
-<td style="width: 1.5%;" colspan="1">
-spl
-</td>
-<td style="width: 9%;" colspan="7">
-</td>
-<td style="width: 1.5%;" colspan="1">
-bpl
-</td>
-<td style="width: 9%;" colspan="7">
-</td>
-<td style="width: 1.5%;" colspan="1">
-sil
-</td>
-<td style="width: 9%;" colspan="7">
-</td>
-<td style="width: 1.5%;" colspan="1">
-dil
-</td>
-</tr>
+  <tr><th>Register</th><th style="width: 12%;" colspan="8">Accumulator</th><th style="width: 12%;" colspan="8">Counter</th><th style="width: 12%;" colspan="8">Data</th><th style="width: 12%;" colspan="8">Base</th><th style="width: 12%;" colspan="8">Stack Pointer</th><th style="width: 12%;" colspan="8">Stack Base Pointer</th><th style="width: 12%;" colspan="8">Source</th><th style="width: 12%;" colspan="8">Destination</th></tr>
+  <tr style="text-align: center;"><th scope="row">64-bit</th><td colspan="8">rax</td><td colspan="8">rcx</td><td colspan="8">rdx</td><td colspan="8">rbx</td><td colspan="8">rsp</td><td colspan="8">rbp</td><td colspan="8">rsi</td><td colspan="8">rdi</td></tr>
+  <tr style="text-align: center;"><th scope="row">32-bit</th><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">eax</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">ecx</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">edx</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">ebx</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">esp</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">ebp</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">esi</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">edi</td></tr>
+  <tr style="text-align: center;"><th scope="row">16-bit</th><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">ax</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">cx</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">dx</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">bx</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">sp</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">bp</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">si</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">di</td></tr>
+  <tr style="text-align: center;"><th scope="row">8-bit</th><td style="width: 9%;" colspan="6"></td><td style="width: 1.5%;" colspan="1">ah</td><td style="width: 1.5%;" colspan="1">al</td><td style="width: 9%;" colspan="6"></td><td style="width: 1.5%;" colspan="1">ch</td><td style="width: 1.5%;" colspan="1">cl</td><td style="width: 9%;" colspan="6"></td><td style="width: 1.5%;" colspan="1">dh</td><td style="width: 1.5%;" colspan="1">dl</td><td style="width: 9%;" colspan="6"></td><td style="width: 1.5%;" colspan="1">bh</td><td style="width: 1.5%;" colspan="1">bl</td><td style="width: 9%;" colspan="7"></td><td style="width: 1.5%;" colspan="1">spl</td><td style="width: 9%;" colspan="7"></td><td style="width: 1.5%;" colspan="1">bpl</td><td style="width: 9%;" colspan="7"></td><td style="width: 1.5%;" colspan="1">sil</td><td style="width: 9%;" colspan="7"></td><td style="width: 1.5%;" colspan="1">dil</td></tr>
 </tbody>
-<caption>
-</caption>
+<caption></caption>
 </table>
+
 <h2 id="verbotene-register">Verbotene Register</h2>
 <p>Folgende Register sollten nicht benutzt werden. Das schließt die
 kleineren Register mit ein.</p>
 <table style="background-color: #f8f9fa;color: #202122;margin: 1em 0;border: 1px solid #a2a9b1;border-collapse: collapse;">
 <tbody>
-<tr>
-<th>
-Register
-</th>
-<th>
-Zugehörig
-</th>
-<th>
-Grund
-</th>
-</tr>
-<tr>
-<td>
-rbp
-</td>
-<td>
-ebp, bp, bpl
-</td>
-<td>
-Pointer zur vorherigen Stackframe.
-</td>
-</tr>
-<tr>
-<td>
-rsp
-</td>
-<td>
-esp, sp, sple
-</td>
-<td>
-Markiert die Position des obersten Eintrags im Stack.
-</td>
-</tr>
-<tr>
-<td>
-rbx
-</td>
-<td>
-ebx, bx, bh, bl
-</td>
-<td>
-Vorgabe, wird direkt für die Steuerung des Programmablaufs genutzt.
-</td>
-</tr>
-<tr>
-<td>
-r12
-</td>
-<td>
-r12d, r12w, r12b
-</td>
-<td>
-Reserviert für interne Abläufe. Kann genutzt werden, falls der Wert
-manuell gespeichert wurde.
-</td>
-</tr>
-<tr>
-<td>
-r13
-</td>
-<td>
-r13d, r13w, r13b
-</td>
-<td>
-Reserviert laut Standard.
-</td>
-</tr>
-<tr>
-<td>
-r14
-</td>
-<td>
-r14d, r14w, r14b
-</td>
-<td>
-Reserviert laut Standard.
-</td>
-</tr>
-<tr>
-<td>
-r15
-</td>
-<td>
-r15d, r15w, r15b
-</td>
-<td>
-Reserviert laut Standard.
-</td>
-</tr>
-<tr>
-<td>
-rip
-</td>
-<td>
-ip
-</td>
-<td>
-Program counter.
-</td>
-</tr>
-<tr>
-<td>
-rflags
-</td>
-<td>
-eflags, flags
-</td>
-<td>
-Regelt zero flag, carry flag, etc.
-</td>
-</tr>
+<tr><th>Register</th><th>Zugehörig</th><th>Grund</th></tr>
+<tr><td>rbp</td><td>ebp, bp, bpl</td><td>Pointer zur vorherigen Stackframe.</td></tr>
+<tr><td>rsp</td><td>esp, sp, sple</td><td>Markiert die Position des obersten Eintrags im Stack.</td></tr>
+<tr><td>rbx</td><td>ebx, bx, bh, bl</td><td>Vorgabe, wird direkt für die Steuerung des Programmablaufs genutzt.</td></tr>
+<tr><td>r12</td><td>r12d, r12w, r12b</td><td>Reserviert für interne Abläufe. Kann genutzt werden, falls der Wert manuell gespeichert wurde.</td></tr>
+<tr><td>r13</td><td>r13d, r13w, r13b</td><td>Reserviert laut Standard.</td></tr>
+<tr><td>r14</td><td>r14d, r14w, r14b</td><td>Reserviert laut Standard.</td></tr>
+<tr><td>r15</td><td>r15d, r15w, r15b</td><td>Reserviert laut Standard.</td></tr>
+<tr><td>rip</td><td>ip</td><td>Program counter.</td></tr>
+<tr><td>rflags</td><td>eflags, flags</td><td>Regelt zero flag, carry flag, etc.</td></tr>
 </tbody>
-<caption>
-</caption>
+<caption></caption>
 </table>
+
 <h2 id="eingabe-register">Eingabe-Register</h2>
 <p>Funktionsparameter werden in folgenden Registern übermittelt:</p>
 <table>
 <tbody>
-<tr style="text-align: center;">
-<th scope="row">
-Parameter Nummer
-</th>
-<td colspan="8">
-1
-</td>
-<td colspan="8">
-2
-</td>
-<td colspan="8">
-3
-</td>
-<td colspan="8">
-4
-</td>
-<td colspan="8">
-5
-</td>
-<td colspan="8">
-6
-</td>
-<td colspan="8">
-7+
-</td>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-Register
-</th>
-<td colspan="8">
-rdi
-</td>
-<td colspan="8">
-rsi
-</td>
-<td colspan="8">
-rdx
-</td>
-<td colspan="8">
-rcx
-</td>
-<td colspan="8">
-r8
-</td>
-<td colspan="8">
-r9
-</td>
-<td colspan="8">
-Stack
-</td>
-</tr>
+  <tr style="text-align: center;"><th scope="row">Parameter Nummer</th>
+  <td colspan="8">1</td>
+  <td colspan="8">2</td>
+  <td colspan="8">3</td>
+  <td colspan="8">4</td>
+  <td colspan="8">5</td>
+  <td colspan="8">6</td>
+  <td colspan="8">7+</td>
+  </tr>
+  <tr style="text-align: center;"><th scope="row">Register</th>
+  <td colspan="8">rdi</td>
+  <td colspan="8">rsi</td>
+  <td colspan="8">rdx</td>
+  <td colspan="8">rcx</td>
+  <td colspan="8">r8</td>
+  <td colspan="8">r9</td>
+  <td colspan="8">Stack</td>
+  </tr>
 </tbody>
 </table>
+
 <h2 id="rückgabe-register">Rückgabe-Register</h2>
 <p>Der Rückgabewert einer Funktion steht im <code>rax</code> Register.
 Achtet dabei darauf, dass ihr euer Ergebnis immer ins rax Register
 schreibt.</p>
 <p>Für Floating-Point-Zahlen steht das Ergebnis einer Funktion im
 <code>xmm0</code> Register.</p>
-<h2 id="volatile--vs.-non-volatile-register">Volatile-
-vs. Non-Volatile-Register</h2>
+<h2 id="volatile--vs-non-volatile-register">Volatile- vs.
+Non-Volatile-Register</h2>
 <p>Nach Calling-Convention werden die Register in 2 Kategorien
 eingeteilt: Volatile und Non-Volatile. Non-Volatile-Register behalten,
 nach Calling-Convention, nach einem Funktionsaufruf ihren Wert. D.h. wir
@@ -505,7 +171,7 @@ manuell vor dem Aufruf sichern.</p>
 </table>
 <h1 id="befehle">Befehle</h1>
 <h2 id="bewegen-von-daten">Bewegen von Daten:</h2>
-<h3 id="mov-reg-to-value-mov-reg-to-reg-from">mov reg (to), value / mov
+<h3 id="mov-reg-to-value--mov-reg-to-reg-from">mov reg (to), value / mov
 reg (to), reg (from):</h3>
 <p>Definition: Verschiebe ein Wert bzw. den Wert eines Registers in ein
 weiteres Register.</p>
@@ -513,7 +179,7 @@ weiteres Register.</p>
 <pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
-<h3 id="and-reg-value-1-value-and-reg-value-1-reg-value-2">and reg
+<h3 id="and-reg-value-1-value--and-reg-value-1-reg-value-2">and reg
 (value 1), value / and reg (value 1), reg (value 2)</h3>
 <p>Definition: Wendet das logische UND (<span
 class="math inline">\(\land\)</span>) mit dem Wert des zweiten
@@ -532,7 +198,7 @@ and rax, rsi = 0101 1101 and 1101 1011
 1001 1011
 ---------
 0001 1001 = rax</code></pre>
-<h3 id="or-reg-value-1-value-or-reg-value-1-reg-value-2">or reg (value
+<h3 id="or-reg-value-1-value--or-reg-value-1-reg-value-2">or reg (value
 1), value / or reg (value 1), reg (value 2)</h3>
 <p>Definition: Wende das logische ODER (<span
 class="math inline">\(\lor\)</span>) mit dem Wert des zweiten Parameters
@@ -551,7 +217,7 @@ or rdx, 0xf = 0011 1101 or 0000 1101
 0000 1101
 ---------
 0011 1101 = rdx</code></pre>
-<h3 id="xor-reg-value-1-value-xor-reg-value-1-reg-value-2">xor reg
+<h3 id="xor-reg-value-1-value--xor-reg-value-1-reg-value-2">xor reg
 (value 1), value / xor reg (value 1), reg (value 2):</h3>
 <p>Definition: Wendet das logische XOR (<span
 class="math inline">\(\oplus\)</span>) mit dem Wert des zweiten
@@ -576,11 +242,11 @@ zu 1en und umgekehrt).</p>
 <pre><code>; rdx = 0011 1011
 neg rdx
 ; rdx = 1100 0100</code></pre>
-<h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1),
+<h3 id="shl-reg-value-1-value--shl-reg-value-1-cl">shl reg (value 1),
 value / shl reg (value 1), cl</h3>
 <p>Definition: Shifte den Wert des Registers um <span
 class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
-“rausgeschoben” werden gehen verloren</p>
+"rausgeschoben" werden gehen verloren</p>
 <p>Beispiel:</p>
 <pre><code>shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
 shl rax, 1   ; Verschiebe alle Bits</code></pre>
@@ -595,7 +261,7 @@ shl rax, 1
 begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
 des Count-Registers (<code>cl</code>) angelegt wurde für
 Verschiebungen.</p>
-<h3 id="shr-reg-value-1-value-shr-reg-value-1-cl">shr reg (value 1),
+<h3 id="shr-reg-value-1-value--shr-reg-value-1-cl">shr reg (value 1),
 value / shr reg (value 1), cl</h3>
 <p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
 Also analog zu <code>shl</code>.</p>
@@ -606,7 +272,7 @@ shr rax, 1</code></pre>
 nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
 Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
 Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
-<h3 id="rol-reg-value-1-value-rol-reg-value-1-reg-value-2">rol reg
+<h3 id="rol-reg-value-1-value--rol-reg-value-1-reg-value-2">rol reg
 (value 1), value / rol reg (value 1), reg (value 2)</h3>
 <p>Definition: Rotiere die Werte um <span
 class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
@@ -620,7 +286,7 @@ rol rax, 1</code></pre>
 
 rol rax, 1
 =&gt; rax = 1000 1001</code></pre>
-<h3 id="ror-reg-value-1-value-ror-reg-value-1-reg-value-2">ror reg
+<h3 id="ror-reg-value-1-value--ror-reg-value-1-reg-value-2">ror reg
 (value 1), value / ror reg (value 1), reg (value 2)</h3>
 <p>Definition: Rotiere die Werte um <span
 class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
@@ -634,14 +300,14 @@ ror rax, 1</code></pre>
 Komplement).</p>
 <p>Beispiel:</p>
 <pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
-<h3 id="add-reg-value-1-value-add-reg-value-1-reg-value-2">add reg
+<h3 id="add-reg-value-1-value--add-reg-value-1-reg-value-2">add reg
 (value 1), value / add reg (value 1), reg (value 2):</h3>
 <p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
 Wert eines anderen Registers.</p>
 <p>Beispiel:</p>
 <pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
 add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
-<h3 id="sub-reg-value-1-value-sub-reg-value-1-reg-value-2">sub reg
+<h3 id="sub-reg-value-1-value--sub-reg-value-1-reg-value-2">sub reg
 (value 1), value / sub reg (value 1), reg (value 2):</h3>
 <p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
 <p>Beispiele:</p>
@@ -677,7 +343,7 @@ idiv reg (value 1):</h3>
 mit Vorzeichen)</p>
 <h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und
 Bedinge Sprünge:</h2>
-<h3 id="cmp-reg-value-1-value-cmp-reg-value-1-reg-value-2">cmp reg
+<h3 id="cmp-reg-value-1-value--cmp-reg-value-1-reg-value-2">cmp reg
 (value 1), value / cmp reg (value 1), reg (value 2):</h3>
 <p>Definition: Vergleiche ein Register mit einem Wert bzw. mit dem Wert
 eines weiteren Registers. Diese Operation setzt Bits im Flag-Register
@@ -699,15 +365,11 @@ jmp .some_label
 ; [Do something]</code></pre>
 <h3 id="jx-some_label">j<em>X</em> some_label:</h3>
 <p>(<em>X</em> wird durch eine von vielen Bezeichnungen ersetzt:
-<code>je</code>, <code>jne</code>, …)</p>
+<code>je</code>, <code>jne</code>, ...)</p>
 <p>Definition: Springe, wenn bestimmte Bits im Flag-Register gesetzt
 sind. Dies wird in der Regel in Kombination mit einer
 Vergleich-Operation genutzt, um diese Bits zu setzen.</p>
 <table>
-<colgroup>
-<col style="width: 67%" />
-<col style="width: 32%" />
-</colgroup>
 <thead>
 <tr class="header">
 <th>Sprung Bezeichnung</th>
@@ -717,52 +379,52 @@ Vergleich-Operation genutzt, um diese Bits zu setzen.</p>
 <tbody>
 <tr class="odd">
 <td><code>je</code></td>
-<td>“Jump equal” – Springe, wenn der Vergleich ergeben hat, dass die
+<td>"Jump equal" -- Springe, wenn der Vergleich ergeben hat, dass die
 Werte die selben sind</td>
 </tr>
 <tr class="even">
 <td><code>jne</code></td>
-<td>“Jump not equal” – Springe, wenn der Vergleich ergeben hat, dass die
-Werte ungleich sind</td>
+<td>"Jump not equal" -- Springe, wenn der Vergleich ergeben hat, dass
+die Werte ungleich sind</td>
 </tr>
 <tr class="odd">
 <td><code>jb</code></td>
-<td>“Jump below” – Springe wenn <span class="math inline">\(\text{reg1}
+<td>"Jump below" -- Springe wenn <span class="math inline">\(\text{reg1}
 &lt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1}
 &lt; \text{value}\)</span> (unsigned number)</td>
 </tr>
 <tr class="even">
 <td><code>ja</code></td>
-<td>“Jump above” – Springe wenn <span class="math inline">\(\text{reg1}
+<td>"Jump above" -- Springe wenn <span class="math inline">\(\text{reg1}
 &gt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1}
 &gt; \text{value}\)</span> (unsigned number)</td>
 </tr>
 <tr class="odd">
 <td><code>jl</code></td>
-<td>“Jump less” – Springe wenn <span class="math inline">\(\text{reg1}
+<td>"Jump less" -- Springe wenn <span class="math inline">\(\text{reg1}
 &lt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1}
 &lt; \text{value}\)</span> (signed number)</td>
 </tr>
 <tr class="even">
 <td><code>jg</code></td>
-<td>“Jump greater” – Springe wenn <span
+<td>"Jump greater" -- Springe wenn <span
 class="math inline">\(\text{reg1} &gt; \text{reg2}\)</span> oder <span
 class="math inline">\(\text{reg1} &gt; \text{value}\)</span> (signed
 number)</td>
 </tr>
 <tr class="odd">
 <td><code>jz</code></td>
-<td>“Jump zero” – Äquivalent zu <code>je</code>. Springe wenn das
+<td>"Jump zero" -- Äquivalent zu <code>je</code>. Springe wenn das
 Ergebnis 0 ist.</td>
 </tr>
 <tr class="even">
 <td><code>jnz</code></td>
-<td>“Jump not zero” – Äquivalent zu <code>jne</code>. Springe wenn das
+<td>"Jump not zero" -- Äquivalent zu <code>jne</code>. Springe wenn das
 Ergebnis nicht 0 ist.</td>
 </tr>
 <tr class="odd">
-<td><code>jle</code> / <code>jge</code> / …</td>
-<td>“Jump less equal” / “Jump greater equal” – Analog zu den Sprüngen
+<td><code>jle</code> / <code>jge</code> / ...</td>
+<td>"Jump less equal" / "Jump greater equal" -- Analog zu den Sprüngen
 oben nur mit equal</td>
 </tr>
 </tbody>
@@ -776,7 +438,7 @@ jl .some_label
 
 .some_label:
 ; execute here if rax &lt; 2</code></pre>
-<h3 id="test-reg-value-1-value-test-reg-value-1-reg-value-2">test reg
+<h3 id="test-reg-value-1-value--test-reg-value-1-reg-value-2">test reg
 (value 1), value / test reg (value 1), reg (value 2):</h3>
 <p>Definition: Führt ein logisches UND (<span
 class="math inline">\(\land\)</span>) auf das erste Register mit dem
@@ -806,8 +468,8 @@ werden zwei Werte vorgehalten: der (Stack-)Base-Pointer (oder
 Frame-Pointer) und der Stack-Pointer. Der Base-Pointer zeigt immer auf
 den Beginn des Stacks währenddessen der Stack-Pointer auf die nächste
 belegte Adresse zeigt. Der Stack wächst, wenn <code>rsp</code> kleiner
-wird. Daher “wächst” der Stack nach unten. (Der Stack ist “full
-descending”.)</p>
+wird. Daher "wächst" der Stack nach unten. (Der Stack ist "full
+descending".)</p>
 <p>WICHTIG: nach dem Funktionsaufruf (also vor dem ret Befehl) muss der
 Stack-Pointer wieder auf der selben Stelle sein wie zu Beginn des
 Funktionsaufrufs!</p>
@@ -854,7 +516,7 @@ some_other_function:
     ret</code></pre>
 <h1 id="assembly-tricks">Assembly-Tricks:</h1>
 <h3 id="ein-register-auf-0-setzen-clean-oder-bereinigen">Ein Register
-auf 0 setzen (“clean” oder “bereinigen”)</h3>
+auf 0 setzen ("clean" oder "bereinigen")</h3>
 <p>Um den Wert eines Registers auf 0 zu setzen könnt ihr einfach die
 Zahl 0 in das jeweilige Register setzen:</p>
 <pre><code>mov rax, 0 ; Setze rax = 0</code></pre>
@@ -879,31 +541,22 @@ id="ganzzahlige-multiplikationdivision-um-eine-zweier-potenz">Ganzzahlige
 Multiplikation/Division um eine zweier Potenz</h3>
 <p>Die Multiplikation bzw. die Division einer Zahl der Basis <span
 class="math inline">\(b\)</span> mit einer Zahl der Form <span
-class="math inline">\(b^n\)</span> kann als einfache “Verschiebung” um
+class="math inline">\(b^n\)</span> kann als einfache "Verschiebung" um
 <span class="math inline">\(n\)</span> Stellen betrachtet werden. Gucken
 wir uns dies zuerst im Dezimalsystem mit 10-er Potenzen an:</p>
-<p><span class="math display">\[\begin{align*}
-    12 \cdot 10^1 &amp;= 12 \cdot 10   &amp;&amp;= 120 \\
-    12 \cdot 10^2 &amp;= 12 \cdot 100  &amp;&amp;= 1200 \\
-    12 \cdot 10^3 &amp;= 12 \cdot 1000 &amp;&amp;= 12000
-\end{align*}\]</span></p>
-<p><span class="math display">\[\begin{align*}
-    12 \div 10^1 &amp;= 12 \div 10   &amp;&amp;= 1.2 \\
-    12 \div 10^2 &amp;= 12 \div 100  &amp;&amp;= 0.12 \\
-    12 \div 10^3 &amp;= 12 \div 1000 &amp;&amp;= 0.012
-\end{align*}\]</span></p>
+<p>\begin{align*} 12 \cdot 10^1 &amp;= 12 \cdot 10 &amp;&amp;= 120 \ 12
+\cdot 10^2 &amp;= 12 \cdot 100 &amp;&amp;= 1200 \ 12 \cdot 10^3 &amp;=
+12 \cdot 1000 &amp;&amp;= 12000 \end{align*}</p>
+<p>\begin{align*} 12 \div 10^1 &amp;= 12 \div 10 &amp;&amp;= 1.2 \ 12
+\div 10^2 &amp;= 12 \div 100 &amp;&amp;= 0.12 \ 12 \div 10^3 &amp;= 12
+\div 1000 &amp;&amp;= 0.012 \end{align*}</p>
 <p>Im Binärsystem gilt dieses Prinzip natürlich auch:</p>
-<p><span class="math display">\[\begin{align*}
-    0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10} &amp;&amp;= 0110_2
-\\
-    0011_2 \cdot 2_{10}^2 &amp;= 0011_2 \cdot 4_{10} &amp;&amp;= 1100_2
-\end{align*}\]</span></p>
-<p><span class="math display">\[\begin{align*}
-    0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10} &amp;&amp;=
-0001(.1000)_2 \\
-    0011_2 \div 2_{10}^2 &amp;= 0011_2 \div 4_{10} &amp;&amp;=
-0000(.1100)_2
-\end{align*}\]</span></p>
+<p>\begin{align*} 0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10}
+&amp;&amp;= 0110_2 \ 0011_2 \cdot 2_{10}^2 &amp;= 0011_2 \cdot 4_{10}
+&amp;&amp;= 1100_2 \end{align*}</p>
+<p>\begin{align*} 0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10}
+&amp;&amp;= 0001(.1000)<em>2 \ 0011_2 \div 2</em>{10}^2 &amp;= 0011_2
+\div 4_{10} &amp;&amp;= 0000(.1100)_2 \end{align*}</p>
 <p>Hinweise:</p>
 <ol type="1">
 <li>Wir geben mit den Subscripts die Basis der Zahlendarstellung
@@ -930,7 +583,8 @@ Verbindung zugreifen.</p>
 Command-Line und initiiert die Verbindung über SSH:</p>
 <pre><code>$ ssh ZEDAT_USER_NAME@andorra.imp.fu-berlin.de</code></pre>
 <p>Ähnlich funktioniert dies auch für die anderen Remote-Systeme der
-Uni: http://www.mi.fu-berlin.de/w/IT/ItServicesTerminalserver</p>
+Uni: <a
+href="http://www.mi.fu-berlin.de/w/IT/ItServicesTerminalserver">http://www.mi.fu-berlin.de/w/IT/ItServicesTerminalserver</a></p>
 <h2 id="copying-files-sshscp">Copying files (SSH/SCP)</h2>
 <p>Um Dateien von eurem System auf die Remotesysteme der Universität zu
 bekommen kann man das auf SSH basierende SCP (Secure-Copy-Protocol)
@@ -944,7 +598,7 @@ diese zunächst Compiled/Übersetzt werden. Dazu erstellt ihr zunächst mit
 Hilfe von NASM eine Objekt-Datei (<code>.o</code>) aus eurem
 Assembly-Code:</p>
 <pre><code>$ nasm -f elf64 -o PROGRAMM_NAME.o PROGRAMM_NAME.asm</code></pre>
-<p>Die Flag “-f elf64” teilt NASM mit, dass die Ausgabe für x64 Linux
+<p>Die Flag "-f elf64" teilt NASM mit, dass die Ausgabe für x64 Linux
 Übersetzt werden soll.</p>
 <p>Nun müsst ihr auch den C-Wrapper compilieren und eine weitere
 Objektdatei erzeugen:</p>
@@ -956,7 +610,7 @@ euren Code hat.</p>
 <p>Anschließend müssen wir noch beide Objektdateien zu einer
 <strong>ausführbaren Datei</strong> verlinken:</p>
 <pre><code>$ c99 -o PROGRAMM_NAME PROGRAMM_NAME_wrapper.o PROGRAMM_NAME.o</code></pre>
-<p>Abschließend solltet ihr eine Datei mit dem Namen “PROGRAMM_NAME”
+<p>Abschließend solltet ihr eine Datei mit dem Namen "PROGRAMM_NAME"
 besitzen. Diese könnt ihr wie folgt ausführen:</p>
 <pre><code>$ ./PROGRAMM_NAMME [parameter 1] [parameter 2] [parameter 3] ...</code></pre>
 <p>Alternativ könnt ihr auch einfach die gegebene MAKEFILE nutzen</p>
@@ -965,7 +619,7 @@ besitzen. Diese könnt ihr wie folgt ausführen:</p>
 <p>Um Einblick in die Ausführung des ASM-Codes zu bekommen kann man
 <code>gdb</code> verwenden. Hierzu findet ihr eine kleine
 Zusammenfassung von Befehlen zur Ausführung des <code>gdb</code> mit
-einer Terminal “UI”:</p>
+einer Terminal "UI":</p>
 <pre><code>$ gdb PROGRAMM_NAME                 Lade deinen code in gdb
 gdb&gt; break SOME_LABEL_IN_YOUR_CODE  Setze einen &quot;Breakpoint&quot; bei dem dein Programm hält
 gdb&gt; tui enable                     Aktiviere die UI
@@ -978,11 +632,16 @@ gdb&gt; quit                           Beende gdb
 $</code></pre>
 <h1 id="quellen">Quellen:</h1>
 <ul>
-<li>https://en.wikibooks.org/wiki/X86_Assembly/X86_Architecture</li>
-<li>https://en.wikipedia.org/wiki/X86_calling_conventions</li>
-<li>https://stackoverflow.com/questions/18024672/what-registers-are-preserved-through-a-linux-x86-64-function-call</li>
-<li>https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html</li>
-<li>https://cs61.seas.harvard.edu/site/2018/Asm1/</li>
+<li><a
+href="https://en.wikibooks.org/wiki/X86_Assembly/X86_Architecture">https://en.wikibooks.org/wiki/X86_Assembly/X86_Architecture</a></li>
+<li><a
+href="https://en.wikipedia.org/wiki/X86_calling_conventions">https://en.wikipedia.org/wiki/X86_calling_conventions</a></li>
+<li><a
+href="https://stackoverflow.com/questions/18024672/what-registers-are-preserved-through-a-linux-x86-64-function-call">https://stackoverflow.com/questions/18024672/what-registers-are-preserved-through-a-linux-x86-64-function-call</a></li>
+<li><a
+href="https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html">https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html</a></li>
+<li><a
+href="https://cs61.seas.harvard.edu/site/2018/Asm1/">https://cs61.seas.harvard.edu/site/2018/Asm1/</a></li>
 </ul>
 </body>
 </html>

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -569,6 +569,13 @@ xor rdx, 0x8f
 1000 1111
 ---------
 0000 1011 = rdx</code></pre>
+<h3 id="not-reg-value-1">not reg (value 1):</h3>
+<p>Definition: Invertiert den Wert im ersten Register (alle 0en werden
+zu 1en und umgekehrt).</p>
+<p>Beispiel:</p>
+<pre><code>; rdx = 0011 1011
+neg rdx
+; rdx = 1100 0100</code></pre>
 <h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1),
 value / shl reg (value 1), cl</h3>
 <p>Definition: Shifte den Wert des Registers um <span

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -770,6 +770,7 @@ einer Terminal "UI":</p>
 gdb&gt; break SOME_LABEL_IN_YOUR_CODE  Setze einen &quot;Breakpoint&quot; bei dem dein Programm hält
 gdb&gt; tui enable                     Aktiviere die UI
 gdb&gt; layout asm                     Zeige den Assembly-Code deines Programms
+gdb&gt; set disassembly-flavor intel   Syntax wie gewohnt darstellen (mov rax,0x0 statt mov $0x0,%rax)
 gdb&gt; layout regs                    Zeige deine Register während des Programmlaufs
 gdb&gt; run                            Starte Ausführung des Programms
 gdb&gt; ni                             Next Instruction

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -169,6 +169,131 @@ manuell vor dem Aufruf sichern.</p>
 </tr>
 </tbody>
 </table>
+<h1 id="befehle-übersicht">Befehle (Übersicht)</h1>
+<p>Notation: reg = Register (<code>rax</code>, ...), imm = Immediate
+(idR. eine Zahl)</p>
+<table>
+<thead>
+<tr class="header">
+<th>Befehl</th>
+<th>Arg1</th>
+<th>Arg2</th>
+<th>Bedeutung</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><a href="#mov-reg-to-value--mov-reg-to-reg-from">mov</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#and-reg1-value--and-reg1-reg2">and</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 &amp; reg2/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#or-reg1-value--or-reg1-reg2">or</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 | reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#xor-reg1-value--xor-reg1-reg2">xor</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 ^ reg2/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#not-reg1">not</a></td>
+<td>reg1</td>
+<td></td>
+<td>reg1 = ~reg1</td>
+</tr>
+<tr class="even">
+<td><a href="#shl-reg1-value--shl-reg1-cl">shl</a></td>
+<td>reg1</td>
+<td><code>cl</code>/imm</td>
+<td>reg1 = reg1 &lt;&lt; <code>cl</code>/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#shr-reg1-value--shr-reg1-cl">shr</a></td>
+<td>reg1</td>
+<td><code>cl</code>/imm</td>
+<td>reg1 = reg1 &gt;&gt; <code>cl</code>/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#neg-reg1">neg</a></td>
+<td>reg1</td>
+<td></td>
+<td>reg1 = -reg1 (2er Komplement)</td>
+</tr>
+<tr class="odd">
+<td><a href="#add-reg1-value--add-reg1-reg2">add</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 + reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#sub-reg1-value--sub-reg1-reg2">sub</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 - reg2/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#mul-reg1">mul</a></td>
+<td>reg1</td>
+<td></td>
+<td><code>rdx:rax</code> = <code>rax</code> * reg1 (unsigned)</td>
+</tr>
+<tr class="even">
+<td><a href="#div-reg1">div</a></td>
+<td>reg1</td>
+<td></td>
+<td><code>rax</code> = <code>rdx:rax</code> / reg1 (Rest in
+<code>rdx</code>)</td>
+</tr>
+<tr class="odd">
+<td><a href="#imul-reg1-und-idiv-reg1">imul</a></td>
+<td>reg1</td>
+<td></td>
+<td><code>rdx:rax</code> = <code>rax</code> * reg1 (signed)</td>
+</tr>
+<tr class="even">
+<td><a href="#imul-reg1-und-idiv-reg1">idiv</a></td>
+<td>reg1</td>
+<td></td>
+<td><code>rax</code> = <code>rdx:rax</code> / reg1 (Rest in
+<code>rdx</code>)</td>
+</tr>
+<tr class="odd">
+<td><a href="#cmp-reg1-value--cmp-reg1-reg2">cmp</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 - reg2/imm (setzt nur <code>rflags</code>)</td>
+</tr>
+<tr class="even">
+<td><a href="#test-reg1-value--test-reg1-reg2">test</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 ^ reg2/imm (setzt nur <code>rflags</code>)</td>
+</tr>
+<tr class="odd">
+<td><a href="#jmp-some_label">jmp</a></td>
+<td>label</td>
+<td></td>
+<td>Sprung zu label (<code>rip</code> = addr of label)</td>
+</tr>
+<tr class="even">
+<td><a href="#jx-some_label">j<em>X</em></a></td>
+<td>label</td>
+<td></td>
+<td>Bedingter Sprung (nur wenn Bedingung erfüllt)</td>
+</tr>
+</tbody>
+</table>
 <h1 id="befehle">Befehle</h1>
 <h2 id="bewegen-von-daten">Bewegen von Daten:</h2>
 <h3 id="mov-reg-to-value--mov-reg-to-reg-from">mov reg (to), value / mov
@@ -179,8 +304,8 @@ weiteres Register.</p>
 <pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
-<h3 id="and-reg-value-1-value--and-reg-value-1-reg-value-2">and reg
-(value 1), value / and reg (value 1), reg (value 2)</h3>
+<h3 id="and-reg1-value--and-reg1-reg2">and reg1, value / and reg1,
+reg2</h3>
 <p>Definition: Wendet das logische UND (<span
 class="math inline">\(\land\)</span>) mit dem Wert des zweiten
 Parameters auf den Wert des ersten Registers an und speichert das
@@ -198,8 +323,7 @@ and rax, rsi = 0101 1101 and 1101 1011
 1001 1011
 ---------
 0001 1001 = rax</code></pre>
-<h3 id="or-reg-value-1-value--or-reg-value-1-reg-value-2">or reg (value
-1), value / or reg (value 1), reg (value 2)</h3>
+<h3 id="or-reg1-value--or-reg1-reg2">or reg1, value / or reg1, reg2</h3>
 <p>Definition: Wende das logische ODER (<span
 class="math inline">\(\lor\)</span>) mit dem Wert des zweiten Parameters
 auf das erste Register an und speichert das Ergebnis im ersten
@@ -217,8 +341,8 @@ or rdx, 0xf = 0011 1101 or 0000 1101
 0000 1101
 ---------
 0011 1101 = rdx</code></pre>
-<h3 id="xor-reg-value-1-value--xor-reg-value-1-reg-value-2">xor reg
-(value 1), value / xor reg (value 1), reg (value 2):</h3>
+<h3 id="xor-reg1-value--xor-reg1-reg2">xor reg1, value / xor reg1,
+reg2:</h3>
 <p>Definition: Wendet das logische XOR (<span
 class="math inline">\(\oplus\)</span>) mit dem Wert des zweiten
 Parameters auf den Wert des ersten Registers an.</p>
@@ -235,15 +359,14 @@ xor rdx, 0x8f
 1000 1111
 ---------
 0000 1011 = rdx</code></pre>
-<h3 id="not-reg-value-1">not reg (value 1):</h3>
+<h3 id="not-reg1">not reg1:</h3>
 <p>Definition: Invertiert den Wert im ersten Register (alle 0en werden
 zu 1en und umgekehrt).</p>
 <p>Beispiel:</p>
 <pre><code>; rdx = 0011 1011
 neg rdx
 ; rdx = 1100 0100</code></pre>
-<h3 id="shl-reg-value-1-value--shl-reg-value-1-cl">shl reg (value 1),
-value / shl reg (value 1), cl</h3>
+<h3 id="shl-reg1-value--shl-reg1-cl">shl reg1, value / shl reg1, cl</h3>
 <p>Definition: Shifte den Wert des Registers um <span
 class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
 "rausgeschoben" werden gehen verloren</p>
@@ -261,8 +384,7 @@ shl rax, 1
 begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
 des Count-Registers (<code>cl</code>) angelegt wurde für
 Verschiebungen.</p>
-<h3 id="shr-reg-value-1-value--shr-reg-value-1-cl">shr reg (value 1),
-value / shr reg (value 1), cl</h3>
+<h3 id="shr-reg1-value--shr-reg1-cl">shr reg1, value / shr reg1, cl</h3>
 <p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
 Also analog zu <code>shl</code>.</p>
 <p>Beispiel:</p>
@@ -272,8 +394,8 @@ shr rax, 1</code></pre>
 nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
 Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
 Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
-<h3 id="rol-reg-value-1-value--rol-reg-value-1-reg-value-2">rol reg
-(value 1), value / rol reg (value 1), reg (value 2)</h3>
+<h3 id="rol-reg1-value--rol-reg1-reg2">rol reg1, value / rol reg1,
+reg2</h3>
 <p>Definition: Rotiere die Werte um <span
 class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
 gehen hier die Bits die nach links raus geschoben werden nicht verloren,
@@ -286,8 +408,8 @@ rol rax, 1</code></pre>
 
 rol rax, 1
 =&gt; rax = 1000 1001</code></pre>
-<h3 id="ror-reg-value-1-value--ror-reg-value-1-reg-value-2">ror reg
-(value 1), value / ror reg (value 1), reg (value 2)</h3>
+<h3 id="ror-reg1-value--ror-reg1-reg2">ror reg1, value / ror reg1,
+reg2</h3>
 <p>Definition: Rotiere die Werte um <span
 class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <code>rol</code></p>
@@ -295,25 +417,25 @@ class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <pre><code>ror rax, rdx
 ror rax, 1</code></pre>
 <h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
-<h3 id="neg-reg-value-1">neg reg (value 1):</h3>
+<h3 id="neg-reg1">neg reg1:</h3>
 <p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
 Komplement).</p>
 <p>Beispiel:</p>
 <pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
-<h3 id="add-reg-value-1-value--add-reg-value-1-reg-value-2">add reg
-(value 1), value / add reg (value 1), reg (value 2):</h3>
+<h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
+reg2:</h3>
 <p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
 Wert eines anderen Registers.</p>
 <p>Beispiel:</p>
 <pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
 add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
-<h3 id="sub-reg-value-1-value--sub-reg-value-1-reg-value-2">sub reg
-(value 1), value / sub reg (value 1), reg (value 2):</h3>
+<h3 id="sub-reg1-value--sub-reg1-reg2">sub reg1, value / sub reg1,
+reg2:</h3>
 <p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
 <p>Beispiele:</p>
 <pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
 sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
-<h3 id="mul-reg-value-1">mul reg (value 1):</h3>
+<h3 id="mul-reg1">mul reg1:</h3>
 <p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
 angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>
 Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in
@@ -325,7 +447,7 @@ Falls man das Register rax mit einem bestimmten Wert multiplizieren
 möchte muss man diesen vorher in ein Register verschieben:</p>
 <pre><code>mov rsi, 3
 mul rsi    ; Multipliziere rax mit 3</code></pre>
-<h3 id="div-reg-value-1">div reg (value 1):</h3>
+<h3 id="div-reg1">div reg1:</h3>
 <p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax)
 durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
 (ganzzahlige Division) und rdx (Rest) gespeichert</p>
@@ -337,14 +459,13 @@ Muster:</p>
 <pre><code>mov rsi, 3
 mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
 div rsi    ; Dividiere rax durch 3</code></pre>
-<h3 id="imul-reg-value-1-und-idiv-reg-value-1">imul reg (value 1) und
-idiv reg (value 1):</h3>
+<h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
 <p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen
 mit Vorzeichen)</p>
 <h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und
 Bedinge Sprünge:</h2>
-<h3 id="cmp-reg-value-1-value--cmp-reg-value-1-reg-value-2">cmp reg
-(value 1), value / cmp reg (value 1), reg (value 2):</h3>
+<h3 id="cmp-reg1-value--cmp-reg1-reg2">cmp reg1, value / cmp reg1,
+reg2:</h3>
 <p>Definition: Vergleiche ein Register mit einem Wert bzw. mit dem Wert
 eines weiteren Registers. Diese Operation setzt Bits im Flag-Register
 die später für Bedingte-Sprünge verwendet werden könnten</p>
@@ -438,8 +559,8 @@ jl .some_label
 
 .some_label:
 ; execute here if rax &lt; 2</code></pre>
-<h3 id="test-reg-value-1-value--test-reg-value-1-reg-value-2">test reg
-(value 1), value / test reg (value 1), reg (value 2):</h3>
+<h3 id="test-reg1-value--test-reg1-reg2">test reg1, value / test reg1,
+reg2:</h3>
 <p>Definition: Führt ein logisches UND (<span
 class="math inline">\(\land\)</span>) auf das erste Register mit dem
 Wert des zweiten Registers bzw. dem angegebenen Wert aus. Das Ergebnis

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -189,104 +189,122 @@ manuell vor dem Aufruf sichern.</p>
 <td>reg1 = reg2/imm</td>
 </tr>
 <tr class="even">
-<td><a href="#and-reg1-value--and-reg1-reg2">and</a></td>
-<td>reg1</td>
-<td>reg2/imm</td>
-<td>reg1 = reg1 &amp; reg2/imm</td>
-</tr>
-<tr class="odd">
-<td><a href="#or-reg1-value--or-reg1-reg2">or</a></td>
-<td>reg1</td>
-<td>reg2/imm</td>
-<td>reg1 = reg1 | reg2/imm</td>
-</tr>
-<tr class="even">
-<td><a href="#xor-reg1-value--xor-reg1-reg2">xor</a></td>
-<td>reg1</td>
-<td>reg2/imm</td>
-<td>reg1 = reg1 ^ reg2/imm</td>
-</tr>
-<tr class="odd">
-<td><a href="#not-reg1">not</a></td>
-<td>reg1</td>
 <td></td>
-<td>reg1 = ~reg1</td>
-</tr>
-<tr class="even">
-<td><a href="#shl-reg1-value--shl-reg1-cl">shl</a></td>
-<td>reg1</td>
-<td><code>cl</code>/imm</td>
-<td>reg1 = reg1 &lt;&lt; <code>cl</code>/imm</td>
+<td></td>
+<td></td>
+<td></td>
 </tr>
 <tr class="odd">
-<td><a href="#shr-reg1-value--shr-reg1-cl">shr</a></td>
-<td>reg1</td>
-<td><code>cl</code>/imm</td>
-<td>reg1 = reg1 &gt;&gt; <code>cl</code>/imm</td>
-</tr>
-<tr class="even">
 <td><a href="#add-reg1-value--add-reg1-reg2">add</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 = reg1 + reg2/imm</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="#sub-reg1-value--sub-reg1-reg2">sub</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 = reg1 - reg2/imm</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#neg-reg1">neg</a></td>
 <td>reg1</td>
 <td></td>
 <td>reg1 = -reg1 (2er Komplement)</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="#mul-reg1">mul</a></td>
 <td>reg1</td>
 <td></td>
 <td><code>rdx:rax</code> = <code>rax</code> * reg1 (unsigned)</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#div-reg1">div</a></td>
 <td>reg1</td>
 <td></td>
 <td><code>rax</code> = <code>rdx:rax</code> / reg1 (Rest in
 <code>rdx</code>)</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="#imul-reg1-und-idiv-reg1">imul</a></td>
 <td>reg1</td>
 <td></td>
 <td><code>rdx:rax</code> = <code>rax</code> * reg1 (signed)</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#imul-reg1-und-idiv-reg1">idiv</a></td>
 <td>reg1</td>
 <td></td>
 <td><code>rax</code> = <code>rdx:rax</code> / reg1 (Rest in
 <code>rdx</code>)</td>
 </tr>
+<tr class="even">
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
 <tr class="odd">
+<td><a href="#and-reg1-value--and-reg1-reg2">and</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 &amp; reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#or-reg1-value--or-reg1-reg2">or</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 | reg2/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#xor-reg1-value--xor-reg1-reg2">xor</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 ^ reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#not-reg1">not</a></td>
+<td>reg1</td>
+<td></td>
+<td>reg1 = ~reg1</td>
+</tr>
+<tr class="odd">
+<td><a href="#shl-reg1-value--shl-reg1-cl">shl</a></td>
+<td>reg1</td>
+<td><code>cl</code>/imm</td>
+<td>reg1 = reg1 &lt;&lt; <code>cl</code>/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#shr-reg1-value--shr-reg1-cl">shr</a></td>
+<td>reg1</td>
+<td><code>cl</code>/imm</td>
+<td>reg1 = reg1 &gt;&gt; <code>cl</code>/imm</td>
+</tr>
+<tr class="odd">
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="even">
 <td><a href="#cmp-reg1-value--cmp-reg1-reg2">cmp</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 - reg2/imm (setzt nur <code>rflags</code>)</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#test-reg1-value--test-reg1-reg2">test</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 ^ reg2/imm (setzt nur <code>rflags</code>)</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="#jmp-some_label">jmp</a></td>
 <td>label</td>
 <td></td>
 <td>Sprung zu label (<code>rip</code> = addr of label)</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#jx-some_label">j<em>X</em></a></td>
 <td>label</td>
 <td></td>
@@ -303,6 +321,52 @@ weiteres Register.</p>
 <p>Beispiel:</p>
 <pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
+<h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
+<h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
+reg2:</h3>
+<p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
+Wert eines anderen Registers.</p>
+<p>Beispiel:</p>
+<pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
+add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
+<h3 id="sub-reg1-value--sub-reg1-reg2">sub reg1, value / sub reg1,
+reg2:</h3>
+<p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
+<p>Beispiele:</p>
+<pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
+sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
+<h3 id="neg-reg1">neg reg1:</h3>
+<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
+Komplement).</p>
+<p>Beispiel:</p>
+<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
+<h3 id="mul-reg1">mul reg1:</h3>
+<p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
+angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>
+Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in
+rax passiert)</p>
+<p>Beispiel:</p>
+<pre><code>mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</code></pre>
+<p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden.
+Falls man das Register rax mit einem bestimmten Wert multiplizieren
+möchte muss man diesen vorher in ein Register verschieben:</p>
+<pre><code>mov rsi, 3
+mul rsi    ; Multipliziere rax mit 3</code></pre>
+<h3 id="div-reg1">div reg1:</h3>
+<p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax)
+durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
+(ganzzahlige Division) und rdx (Rest) gespeichert</p>
+<p>Beispiel:</p>
+<pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
+<p>ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax. Also
+aufpassen, dass nicht ungewollt noch was in rdx steht. Übliches
+Muster:</p>
+<pre><code>mov rsi, 3
+mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
+div rsi    ; Dividiere rax durch 3</code></pre>
+<h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
+<p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen
+mit Vorzeichen)</p>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
 <h3 id="and-reg1-value--and-reg1-reg2">and reg1, value / and reg1,
 reg2</h3>
@@ -416,52 +480,6 @@ class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <p>Beispiel:</p>
 <pre><code>ror rax, rdx
 ror rax, 1</code></pre>
-<h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
-<h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
-reg2:</h3>
-<p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
-Wert eines anderen Registers.</p>
-<p>Beispiel:</p>
-<pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
-add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
-<h3 id="sub-reg1-value--sub-reg1-reg2">sub reg1, value / sub reg1,
-reg2:</h3>
-<p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
-<p>Beispiele:</p>
-<pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
-sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
-<h3 id="neg-reg1">neg reg1:</h3>
-<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
-Komplement).</p>
-<p>Beispiel:</p>
-<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
-<h3 id="mul-reg1">mul reg1:</h3>
-<p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
-angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>
-Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in
-rax passiert)</p>
-<p>Beispiel:</p>
-<pre><code>mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</code></pre>
-<p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden.
-Falls man das Register rax mit einem bestimmten Wert multiplizieren
-möchte muss man diesen vorher in ein Register verschieben:</p>
-<pre><code>mov rsi, 3
-mul rsi    ; Multipliziere rax mit 3</code></pre>
-<h3 id="div-reg1">div reg1:</h3>
-<p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax)
-durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
-(ganzzahlige Division) und rdx (Rest) gespeichert</p>
-<p>Beispiel:</p>
-<pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
-<p>ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax. Also
-aufpassen, dass nicht ungewollt noch was in rdx steht. Übliches
-Muster:</p>
-<pre><code>mov rsi, 3
-mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
-div rsi    ; Dividiere rax durch 3</code></pre>
-<h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
-<p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen
-mit Vorzeichen)</p>
 <h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und
 Bedinge Sprünge:</h2>
 <h3 id="cmp-reg1-value--cmp-reg1-reg2">cmp reg1, value / cmp reg1,

--- a/Cheat-Sheet.html
+++ b/Cheat-Sheet.html
@@ -781,6 +781,10 @@ href="https://stackoverflow.com/questions/18024672/what-registers-are-preserved-
 href="https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html">https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html</a></li>
 <li><a
 href="https://cs61.seas.harvard.edu/site/2018/Asm1/">https://cs61.seas.harvard.edu/site/2018/Asm1/</a></li>
+<li><a
+href="https://www.felixcloutier.com/x86/">https://www.felixcloutier.com/x86/</a>
+(all x86 instructions, including detailled description e.g. affected
+flags)</li>
 </ul>
 </body>
 </html>

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -111,69 +111,6 @@ Beispiel:
 	mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 	mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)
 
-### shl reg (value 1), value / shl reg (value 1), cl
-Definition:
-Shifte den Wert des Registers um $n$ Stellen nach Links.
-Bits die nach Links "rausgeschoben" werden gehen verloren
-
-Beispiel:
-
-	shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
-	shl rax, 1   ; Verschiebe alle Bits
-
-Beispiel under the hood:
-
-	rax = 1100 0011
-
-	shl rax, 1
-
-	=> rax = 1000 0110
-
-ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register `cl` als
-Registerverschiebungswert nehmen!
-Dies ist dadurch begründet, dass bei der Entwicklung eines x86-Chips nur eine
-Verbindung des Count-Registers (`cl`) angelegt wurde für Verschiebungen.
-
-### shr reg (value 1), value / shr reg (value 1), cl
-Definition:
-Shifte den Wert des Registers um n Stellen nach Rechts. Also analog zu `shl`.
-
-Beispiel:
-
-	shr rax, cl
-	shr rax, 1
-
-ACHTUNG: Sowohl `shr`, als auch `shl` können nur das Register `cl` als
-Registerverschiebungswert nutzen!
-Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des Count-Registers
-(`cl`) für Verschiebungen angelegt.
-
-### rol reg (value 1), value / rol reg (value 1), reg (value 2)
-Definition: Rotiere die Werte um $n$ Stellen.
-Dies ist Analog zu shl jedoch gehen hier die Bits die nach links raus
-geschoben werden nicht verloren, sondern werden rechts hinzugefügt.
-
-Beispiel:
-
-	rol rax, rdx
-	rol rax, 1
-
-Beispiel under the hood:
-
-	rax = 1100 0100
-
-	rol rax, 1
-	=> rax = 1000 1001
-
-
-### ror reg (value 1), value / ror reg (value 1), reg (value 2)
-Definition: Rotiere die Werte um $n$ Stellen nach Rechts. Also analog zu `rol`
-
-Beispiel:
-
-	ror rax, rdx
-	ror rax, 1
-
 ## Bit-Operationen:
 
 ### and reg (value 1), value / and reg (value 1), reg (value 2)
@@ -241,6 +178,69 @@ Beispiel under the hood:
 	1000 1111
 	---------
 	0000 1011 = rdx
+
+### shl reg (value 1), value / shl reg (value 1), cl
+Definition:
+Shifte den Wert des Registers um $n$ Stellen nach Links.
+Bits die nach Links "rausgeschoben" werden gehen verloren
+
+Beispiel:
+
+	shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
+	shl rax, 1   ; Verschiebe alle Bits
+
+Beispiel under the hood:
+
+	rax = 1100 0011
+
+	shl rax, 1
+
+	=> rax = 1000 0110
+
+ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register `cl` als
+Registerverschiebungswert nehmen!
+Dies ist dadurch begründet, dass bei der Entwicklung eines x86-Chips nur eine
+Verbindung des Count-Registers (`cl`) angelegt wurde für Verschiebungen.
+
+### shr reg (value 1), value / shr reg (value 1), cl
+Definition:
+Shifte den Wert des Registers um n Stellen nach Rechts. Also analog zu `shl`.
+
+Beispiel:
+
+	shr rax, cl
+	shr rax, 1
+
+ACHTUNG: Sowohl `shr`, als auch `shl` können nur das Register `cl` als
+Registerverschiebungswert nutzen!
+Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des Count-Registers
+(`cl`) für Verschiebungen angelegt.
+
+### rol reg (value 1), value / rol reg (value 1), reg (value 2)
+Definition: Rotiere die Werte um $n$ Stellen.
+Dies ist Analog zu shl jedoch gehen hier die Bits die nach links raus
+geschoben werden nicht verloren, sondern werden rechts hinzugefügt.
+
+Beispiel:
+
+	rol rax, rdx
+	rol rax, 1
+
+Beispiel under the hood:
+
+	rax = 1100 0100
+
+	rol rax, 1
+	=> rax = 1000 1001
+
+
+### ror reg (value 1), value / ror reg (value 1), reg (value 2)
+Definition: Rotiere die Werte um $n$ Stellen nach Rechts. Also analog zu `rol`
+
+Beispiel:
+
+	ror rax, rdx
+	ror rax, 1
 
 ## Arithmetische-Operationen:
 

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -97,6 +97,31 @@ weiteren Funktionsaufruf behalten, müssen wir sie manuell vor dem Aufruf sicher
 | r8-r11   | X        |              |
 | r12-r15  |          | X            |
 
+# Befehle (Übersicht)
+
+Notation: reg = Register (`rax`, ...), imm = Immediate (idR. eine Zahl)
+
+| Befehl | Arg1  | Arg2     | Bedeutung                   |
+|--------|-------|----------|-----------------------------|
+| [mov](#mov-reg-to-value--mov-reg-to-reg-from) | reg1  | reg2/imm | reg1 = reg2/imm |
+| [and](#and-reg1-value--and-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 & reg2/imm |
+| [or](#or-reg1-value--or-reg1-reg2)            | reg1  | reg2/imm | reg1 = reg1 \| reg2/imm |
+| [xor](#xor-reg1-value--xor-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 ^ reg2/imm |
+| [not](#not-reg1)                              | reg1  |          | reg1 = ~reg1 |
+| [shl](#shl-reg1-value--shl-reg1-cl)           | reg1  | `cl`/imm | reg1 = reg1 << `cl`/imm |
+| [shr](#shr-reg1-value--shr-reg1-cl)           | reg1  | `cl`/imm | reg1 = reg1 >> `cl`/imm |
+| [neg](#neg-reg1)                              | reg1  |          | reg1 = -reg1 (2er Komplement) |
+| [add](#add-reg1-value--add-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 + reg2/imm |
+| [sub](#sub-reg1-value--sub-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 - reg2/imm |
+| [mul](#mul-reg1)                              | reg1  |          | `rdx:rax` = `rax` * reg1 (unsigned) |
+| [div](#div-reg1)                              | reg1  |          | `rax` = `rdx:rax` / reg1 (Rest in `rdx`) |
+| [imul](#imul-reg1-und-idiv-reg1)              | reg1  |          | `rdx:rax` = `rax` * reg1 (signed) |
+| [idiv](#imul-reg1-und-idiv-reg1)              | reg1  |          | `rax` = `rdx:rax` / reg1 (Rest in `rdx`) |
+| [cmp](#cmp-reg1-value--cmp-reg1-reg2)         | reg1  | reg2/imm | reg1 - reg2/imm (setzt nur `rflags`) |
+| [test](#test-reg1-value--test-reg1-reg2)      | reg1  | reg2/imm | reg1 ^ reg2/imm (setzt nur `rflags`) |
+| [jmp](#jmp-some_label)                        | label |          | Sprung zu label (`rip` = addr of label) |
+| [j*X*](#jx-some_label)                        | label |          | Bedingter Sprung (nur wenn Bedingung erfüllt) |
+
 
 # Befehle
 
@@ -113,7 +138,7 @@ Beispiel:
 
 ## Bit-Operationen:
 
-### and reg (value 1), value / and reg (value 1), reg (value 2)
+### and reg1, value / and reg1, reg2
 Definition:
 Wendet das logische UND ($\land$) mit dem Wert des zweiten Parameters auf den
 Wert des ersten Registers an und speichert das Ergebnis im ersten Register.
@@ -135,7 +160,7 @@ Beispiel under the hood:
 	---------
 	0001 1001 = rax
 
-### or reg (value 1), value / or reg (value 1), reg (value 2)
+### or reg1, value / or reg1, reg2
 Definition:
 Wende das logische ODER ($\lor$) mit dem Wert des zweiten Parameters auf das
 erste Register an und speichert das Ergebnis im ersten Register.
@@ -157,7 +182,7 @@ Beispiel under the hood:
 	---------
 	0011 1101 = rdx
 
-### xor reg (value 1), value / xor reg (value 1), reg (value 2):
+### xor reg1, value / xor reg1, reg2:
 Definition:
 Wendet das logische XOR ($\oplus$) mit dem Wert des zweiten Parameters auf den
 Wert des ersten Registers an.
@@ -179,7 +204,7 @@ Beispiel under the hood:
 	---------
 	0000 1011 = rdx
 
-### not reg (value 1):
+### not reg1:
 Definition:
 Invertiert den Wert im ersten Register (alle 0en werden zu 1en und umgekehrt).
 
@@ -189,7 +214,7 @@ Beispiel:
 	neg rdx
 	; rdx = 1100 0100
 
-### shl reg (value 1), value / shl reg (value 1), cl
+### shl reg1, value / shl reg1, cl
 Definition:
 Shifte den Wert des Registers um $n$ Stellen nach Links.
 Bits die nach Links "rausgeschoben" werden gehen verloren
@@ -212,7 +237,7 @@ Registerverschiebungswert nehmen!
 Dies ist dadurch begründet, dass bei der Entwicklung eines x86-Chips nur eine
 Verbindung des Count-Registers (`cl`) angelegt wurde für Verschiebungen.
 
-### shr reg (value 1), value / shr reg (value 1), cl
+### shr reg1, value / shr reg1, cl
 Definition:
 Shifte den Wert des Registers um n Stellen nach Rechts. Also analog zu `shl`.
 
@@ -226,7 +251,7 @@ Registerverschiebungswert nutzen!
 Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des Count-Registers
 (`cl`) für Verschiebungen angelegt.
 
-### rol reg (value 1), value / rol reg (value 1), reg (value 2)
+### rol reg1, value / rol reg1, reg2
 Definition: Rotiere die Werte um $n$ Stellen.
 Dies ist Analog zu shl jedoch gehen hier die Bits die nach links raus
 geschoben werden nicht verloren, sondern werden rechts hinzugefügt.
@@ -244,7 +269,7 @@ Beispiel under the hood:
 	=> rax = 1000 1001
 
 
-### ror reg (value 1), value / ror reg (value 1), reg (value 2)
+### ror reg1, value / ror reg1, reg2
 Definition: Rotiere die Werte um $n$ Stellen nach Rechts. Also analog zu `rol`
 
 Beispiel:
@@ -254,7 +279,7 @@ Beispiel:
 
 ## Arithmetische-Operationen:
 
-### neg reg (value 1):
+### neg reg1:
 Definition:
 Negiere den Wert aus dem gegebenen Register (in 2er Komplement).
 
@@ -262,7 +287,7 @@ Beispiel:
 
 	neg rsi ; Negiere den Wert in rsi
 
-### add reg (value 1), value / add reg (value 1), reg (value 2):
+### add reg1, value / add reg1, reg2:
 Definition:
 Addiere einen Wert bzw. den Wert eines Registers auf den Wert eines anderen
 Registers.
@@ -272,7 +297,7 @@ Beispiel:
 	add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
 	add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)
 
-### sub reg (value 1), value / sub reg (value 1), reg (value 2):
+### sub reg1, value / sub reg1, reg2:
 Definition:
 Analog zu `add` jedoch als Subtraktion
 
@@ -281,7 +306,7 @@ Beispiele:
 	sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
 	sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)
 
-### mul reg (value 1):
+### mul reg1:
 Definition:
 Multipliziere den Wert in Register rax mit dem Wert des angegebenen Registers. Das Ergebnis wird in die *beiden (!!!)* Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in rax passiert)
 
@@ -294,7 +319,7 @@ ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden. Falls man das R
 	mov rsi, 3
 	mul rsi    ; Multipliziere rax mit 3
 
-### div reg (value 1):
+### div reg1:
 Definition:
 Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax) durch den Wert aus dem angegebenen Register. Ergebnis wird in rax (ganzzahlige Division) und rdx (Rest) gespeichert
 
@@ -310,13 +335,13 @@ Also aufpassen, dass nicht ungewollt noch was in rdx steht.
 	mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
 	div rsi    ; Dividiere rax durch 3
 
-### imul reg (value 1) und idiv reg (value 1):
+### imul reg1 und idiv reg1:
 Definition:
 Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen mit Vorzeichen)
 
 ## Vergleiche/Sprünge und Bedinge Sprünge:
 
-### cmp reg (value 1), value / cmp reg (value 1), reg (value 2):
+### cmp reg1, value / cmp reg1, reg2:
 Definition:
 Vergleiche ein Register mit einem Wert bzw. mit dem Wert eines weiteren Registers. Diese Operation setzt Bits im Flag-Register die später für Bedingte-Sprünge verwendet werden könnten
 
@@ -350,7 +375,7 @@ Dies wird in der Regel in Kombination mit einer Vergleich-Operation genutzt,
 um diese Bits zu setzen.
 
 | Sprung Bezeichnung   | Bedeutung |
-|--------------------- |---------- |
+|----------------------|-----------|
 | `je`                 | "Jump equal"     -- Springe, wenn der Vergleich ergeben hat, dass die Werte die selben sind |
 | `jne`                | "Jump not equal" -- Springe, wenn der Vergleich ergeben hat, dass die Werte ungleich sind |
 | `jb`                 | "Jump below"     -- Springe wenn $\text{reg1} < \text{reg2}$ oder $\text{reg1} < \text{value}$ (unsigned number) |
@@ -372,7 +397,7 @@ Beispiele:
 	.some_label:
 	; execute here if rax < 2
 
-### test reg (value 1), value / test reg (value 1), reg (value 2):
+### test reg1, value / test reg1, reg2:
 Definition:
 Führt ein logisches UND ($\land$) auf das erste Register mit dem Wert des
 zweiten Registers bzw. dem angegebenen Wert aus.

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -341,7 +341,9 @@ Beispiel:
 	; [Do something]
 
 
-### jl some_label / jb some_label / jg some_label / ja some_label / je some_label / jne some_label ...
+### j*X* some_label:
+(*X* wird durch eine von vielen Bezeichnungen ersetzt: `je`, `jne`, ...)
+
 Definition:
 Springe, wenn bestimmte Bits im Flag-Register gesetzt sind.
 Dies wird in der Regel in Kombination mit einer Vergleich-Operation genutzt,

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -136,8 +136,10 @@ Verschiebe ein Wert bzw. den Wert eines Registers in ein weiteres Register.
 
 Beispiel:
 
-	mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
-	mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)
+```nasm
+mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
+mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)
+```
 
 ## Arithmetische-Operationen:
 
@@ -148,8 +150,10 @@ Registers.
 
 Beispiel:
 
-	add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
-	add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)
+```nasm
+add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
+add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)
+```
 
 ### sub reg1, value / sub reg1, reg2:
 Definition:
@@ -157,8 +161,10 @@ Analog zu `add` jedoch als Subtraktion
 
 Beispiele:
 
-	sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
-	sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)
+```nasm
+sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
+sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)
+```
 
 ### neg reg1:
 Definition:
@@ -166,7 +172,9 @@ Negiere den Wert aus dem gegebenen Register (in 2er Komplement).
 
 Beispiel:
 
-	neg rsi ; Negiere den Wert in rsi
+```nasm
+neg rsi ; Negiere den Wert in rsi
+```
 
 ### mul reg1:
 Definition:
@@ -174,12 +182,16 @@ Multipliziere den Wert in Register `rax` mit dem Wert des angegebenen Registers.
 
 Beispiel:
 
-	mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax
+```nasm
+mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax
+```
 
 ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden. Falls man das Register `rax` mit einem bestimmten Wert multiplizieren möchte muss man diesen vorher in ein Register verschieben:
 
-	mov rsi, 3
-	mul rsi    ; Multipliziere rax mit 3
+```nasm
+mov rsi, 3
+mul rsi    ; Multipliziere rax mit 3
+```
 
 ### div reg1:
 Definition:
@@ -187,15 +199,19 @@ Dividiere den Wert aus `rdx:rax` (`rdx` konkateniert mit `rax`) durch den Wert a
 
 Beispiel:
 
-	div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax
+```nasm
+div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax
+```
 
 ACHTUNG: Der Divisor ist nicht nur `rax`, sondern `rdx:rax`.
 Also aufpassen, dass nicht ungewollt noch was in `rdx` steht.
 Übliches Muster:
 
-	mov rsi, 3
-	mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
-	div rsi    ; Dividiere rax durch 3
+```nasm
+mov rsi, 3
+mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
+div rsi    ; Dividiere rax durch 3
+```
 
 ### imul reg1 und idiv reg1:
 Definition:
@@ -210,8 +226,10 @@ Wert des ersten Registers an und speichert das Ergebnis im ersten Register.
 
 Beispiel:
 
-	and rax, rsi ; Verunde den Wert aus rax mit dem Wert aus rsi
-	and rax, 0x1 ; Verunde den Wert aus rax mit dem Wert 0x1 (Hexadezimal-Zahl)
+```nasm
+and rax, rsi ; Verunde den Wert aus rax mit dem Wert aus rsi
+and rax, 0x1 ; Verunde den Wert aus rax mit dem Wert 0x1 (Hexadezimal-Zahl)
+```
 
 Beispiel under the hood:
 
@@ -232,8 +250,10 @@ erste Register an und speichert das Ergebnis im ersten Register.
 
 Beispiel:
 
-	or rax, rsi ; Veroder den Wert aus rax mit dem Wert aus rsi
-	or rdx, 0xf ; Veroder den Wert aus rdx mit dem Wert 0xf (Binär = 1111)
+```nasm
+or rax, rsi ; Veroder den Wert aus rax mit dem Wert aus rsi
+or rdx, 0xf ; Veroder den Wert aus rdx mit dem Wert 0xf (Binär = 1111)
+```
 
 Beispiel under the hood:
 
@@ -254,8 +274,10 @@ Wert des ersten Registers an.
 
 Beispiel:
 
-	xor rax, rsi  ; Wendet XOR auf den Wert von rax mit dem Wert von rsi an
-	xor rdx, 0x8f ; Wendet XOR auf den Wert von rdx mit 0x8f (Binär = 1000 1111) an
+```nasm
+xor rax, rsi  ; Wendet XOR auf den Wert von rax mit dem Wert von rsi an
+xor rdx, 0x8f ; Wendet XOR auf den Wert von rdx mit 0x8f (Binär = 1000 1111) an
+```
 
 Beispiel under the hood:
 
@@ -275,9 +297,11 @@ Invertiert den Wert im ersten Register (alle 0en werden zu 1en und umgekehrt).
 
 Beispiel:
 
-	; rdx = 0011 1011
-	neg rdx
-	; rdx = 1100 0100
+```nasm
+; rdx = 0011 1011
+neg rdx
+; rdx = 1100 0100
+```
 
 ### shl reg1, value / shl reg1, cl
 Definition:
@@ -286,8 +310,10 @@ Bits die nach Links "rausgeschoben" werden gehen verloren
 
 Beispiel:
 
-	shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
-	shl rax, 1   ; Verschiebe alle Bits
+```nasm
+shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
+shl rax, 1   ; Verschiebe alle Bits
+```
 
 Beispiel under the hood:
 
@@ -308,8 +334,10 @@ Shifte den Wert des Registers um n Stellen nach Rechts. Also analog zu `shl`.
 
 Beispiel:
 
-	shr rax, cl
-	shr rax, 1
+```nasm
+shr rax, cl
+shr rax, 1
+```
 
 ACHTUNG: Sowohl `shr`, als auch `shl` können nur das Register `cl` als
 Registerverschiebungswert nutzen!
@@ -323,8 +351,10 @@ geschoben werden nicht verloren, sondern werden rechts hinzugefügt.
 
 Beispiel:
 
-	rol rax, rdx
-	rol rax, 1
+```nasm
+rol rax, rdx
+rol rax, 1
+```
 
 Beispiel under the hood:
 
@@ -339,8 +369,10 @@ Definition: Rotiere die Werte um $n$ Stellen nach Rechts. Also analog zu `rol`
 
 Beispiel:
 
-	ror rax, rdx
-	ror rax, 1
+```nasm
+ror rax, rdx
+ror rax, 1
+```
 
 ## Vergleiche/Sprünge und Bedinge Sprünge:
 
@@ -350,8 +382,10 @@ Vergleiche ein Register mit einem Wert bzw. mit dem Wert eines weiteren Register
 
 Beispiel:
 
-	cmp rax, rsi ; Vergleiche rax mit dem Wert aus rsi
-	cmp rax, 2   ; Vergleiche rax mit dem Wert 2
+```nasm
+cmp rax, rsi ; Vergleiche rax mit dem Wert aus rsi
+cmp rax, 2   ; Vergleiche rax mit dem Wert 2
+```
 
 ### jmp some_label:
 Definition: Setze den Programm Counter (PC, bzw. `rip`) auf die Adresse des
@@ -361,12 +395,14 @@ An Stelle eines Labels kann auch direkt eine Zahl als Adresse genutzt werden
 
 Beispiel:
 
-	; [...]
-	jmp .some_label
-	; [...]
+```nasm
+; [...]
+jmp .some_label
+; [...]
 
-	.some_label:
-	; [Do something]
+.some_label:
+; [Do something]
+```
 
 
 ### j*X* some_label:
@@ -391,14 +427,16 @@ um diese Bits zu setzen.
 
 Beispiele:
 
-	; [...]
-	cmp rax, 2
-	jl .some_label
-	; execute here if rax >= 2
-	; [...]
+```nasm
+; [...]
+cmp rax, 2
+jl .some_label
+; execute here if rax >= 2
+; [...]
 
-	.some_label:
-	; execute here if rax < 2
+.some_label:
+; execute here if rax < 2
+```
 
 ### test reg1, value / test reg1, reg2:
 Definition:
@@ -443,9 +481,11 @@ aktualisiert den Stack-Pointer.
 
 Beispiel:
 
-	push rax
-	push esi
-	push cl
+```nasm
+push rax
+push esi
+push cl
+```
 
 ### pop reg:
 Definition:
@@ -455,9 +495,11 @@ es in das jeweilige Register.
 
 Beispiel:
 
-	pop cl
-	pop esi
-	pop rax
+```nasm
+pop cl
+pop esi
+pop rax
+```
 
 WICHTIG: Es muss in umgekehrter Reigenfolge gepoppt werden wie die Elemente
 gepusht wurde. Dies ist der Fall wegen der LIFO-Struktur des Stacks!
@@ -478,15 +520,17 @@ Register sichern)
 
 Beispiel:
 
-	some_function:
-		...
-		call some_other_function
-		; ret der subroutine macht hier weiter
-		...
+```nasm
+some_function:
+	...
+	call some_other_function
+	; ret der subroutine macht hier weiter
+	...
 
-	some_other_function:
-		...
-		ret
+some_other_function:
+	...
+	ret
+```
 
 # Assembly-Tricks:
 
@@ -494,7 +538,9 @@ Beispiel:
 Um den Wert eines Registers auf 0 zu setzen könnt ihr einfach die Zahl 0 in das
 jeweilige Register setzen:
 
-	mov rax, 0 ; Setze rax = 0
+```nasm
+mov rax, 0 ; Setze rax = 0
+```
 
 Optional hierzu könnt ihr die `xor`-Instruktion nutzen.
 Da XOR ein gegebenen Bit auf 0 setzt, gdw. beide Register-Einträge 0 sind,
@@ -503,7 +549,9 @@ dass ein XOR mit dem selben Wert das jeweilige Register auf 0 setzen wird.
 Dies hat also den selben Effekt wie ein `mov` Befehl und *kann* unter Umständen
 effizienter sein (konkret ist die Codierungslänge kürzer).
 
-	xor rax, rax ; Setze rax = 0
+```nasm
+xor rax, rax ; Setze rax = 0
+```
 
 	e.g rax = 1101 1111
 
@@ -552,11 +600,13 @@ Hinweise:
 In Assembly können wir also eine Multiplikation bzw. Division eines Registers
 mit einem Wert der Form $2^n$ als $n$-Fachen-Shift implementieren:
 
-	shl rax, 1 ; rax = rax*2
-	shl rax, 2 ; rax = rax*4
+```nasm
+shl rax, 1 ; rax = rax*2
+shl rax, 2 ; rax = rax*4
 
-	shr rax, 1 ; rax = rax/2 (ganzzahlig)
-	shr rax, 2 ; rax = rax/4 (ganzzahlig)
+shr rax, 1 ; rax = rax/2 (ganzzahlig)
+shr rax, 2 ; rax = rax/4 (ganzzahlig)
+```
 
 
 # SSH and working on Andorra

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -629,6 +629,7 @@ Hierzu findet ihr eine kleine Zusammenfassung von Befehlen zur Ausführung des
 	gdb> break SOME_LABEL_IN_YOUR_CODE	Setze einen "Breakpoint" bei dem dein Programm hält
 	gdb> tui enable 					Aktiviere die UI
 	gdb> layout asm						Zeige den Assembly-Code deines Programms
+	gdb> set disassembly-flavor intel   Syntax wie gewohnt darstellen (mov rax,0x0 statt mov $0x0,%rax)
 	gdb> layout regs					Zeige deine Register während des Programmlaufs
 	gdb> run							Starte Ausführung des Programms
 	gdb> ni								Next Instruction

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -104,12 +104,7 @@ Notation: reg = Register (`rax`, ...), imm = Immediate (idR. eine Zahl)
 | Befehl | Arg1  | Arg2     | Bedeutung                   |
 |--------|-------|----------|-----------------------------|
 | [mov](#mov-reg-to-value--mov-reg-to-reg-from) | reg1  | reg2/imm | reg1 = reg2/imm |
-| [and](#and-reg1-value--and-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 & reg2/imm |
-| [or](#or-reg1-value--or-reg1-reg2)            | reg1  | reg2/imm | reg1 = reg1 \| reg2/imm |
-| [xor](#xor-reg1-value--xor-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 ^ reg2/imm |
-| [not](#not-reg1)                              | reg1  |          | reg1 = ~reg1 |
-| [shl](#shl-reg1-value--shl-reg1-cl)           | reg1  | `cl`/imm | reg1 = reg1 << `cl`/imm |
-| [shr](#shr-reg1-value--shr-reg1-cl)           | reg1  | `cl`/imm | reg1 = reg1 >> `cl`/imm |
+| |
 | [add](#add-reg1-value--add-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 + reg2/imm |
 | [sub](#sub-reg1-value--sub-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 - reg2/imm |
 | [neg](#neg-reg1)                              | reg1  |          | reg1 = -reg1 (2er Komplement) |
@@ -117,6 +112,14 @@ Notation: reg = Register (`rax`, ...), imm = Immediate (idR. eine Zahl)
 | [div](#div-reg1)                              | reg1  |          | `rax` = `rdx:rax` / reg1 (Rest in `rdx`) |
 | [imul](#imul-reg1-und-idiv-reg1)              | reg1  |          | `rdx:rax` = `rax` * reg1 (signed) |
 | [idiv](#imul-reg1-und-idiv-reg1)              | reg1  |          | `rax` = `rdx:rax` / reg1 (Rest in `rdx`) |
+| |
+| [and](#and-reg1-value--and-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 & reg2/imm |
+| [or](#or-reg1-value--or-reg1-reg2)            | reg1  | reg2/imm | reg1 = reg1 \| reg2/imm |
+| [xor](#xor-reg1-value--xor-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 ^ reg2/imm |
+| [not](#not-reg1)                              | reg1  |          | reg1 = ~reg1 |
+| [shl](#shl-reg1-value--shl-reg1-cl)           | reg1  | `cl`/imm | reg1 = reg1 << `cl`/imm |
+| [shr](#shr-reg1-value--shr-reg1-cl)           | reg1  | `cl`/imm | reg1 = reg1 >> `cl`/imm |
+| |
 | [cmp](#cmp-reg1-value--cmp-reg1-reg2)         | reg1  | reg2/imm | reg1 - reg2/imm (setzt nur `rflags`) |
 | [test](#test-reg1-value--test-reg1-reg2)      | reg1  | reg2/imm | reg1 ^ reg2/imm (setzt nur `rflags`) |
 | [jmp](#jmp-some_label)                        | label |          | Sprung zu label (`rip` = addr of label) |
@@ -135,6 +138,68 @@ Beispiel:
 
 	mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 	mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)
+
+## Arithmetische-Operationen:
+
+### add reg1, value / add reg1, reg2:
+Definition:
+Addiere einen Wert bzw. den Wert eines Registers auf den Wert eines anderen
+Registers.
+
+Beispiel:
+
+	add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
+	add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)
+
+### sub reg1, value / sub reg1, reg2:
+Definition:
+Analog zu `add` jedoch als Subtraktion
+
+Beispiele:
+
+	sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
+	sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)
+
+### neg reg1:
+Definition:
+Negiere den Wert aus dem gegebenen Register (in 2er Komplement).
+
+Beispiel:
+
+	neg rsi ; Negiere den Wert in rsi
+
+### mul reg1:
+Definition:
+Multipliziere den Wert in Register rax mit dem Wert des angegebenen Registers. Das Ergebnis wird in die *beiden (!!!)* Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in rax passiert)
+
+Beispiel:
+
+	mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax
+
+ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden. Falls man das Register rax mit einem bestimmten Wert multiplizieren möchte muss man diesen vorher in ein Register verschieben:
+
+	mov rsi, 3
+	mul rsi    ; Multipliziere rax mit 3
+
+### div reg1:
+Definition:
+Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax) durch den Wert aus dem angegebenen Register. Ergebnis wird in rax (ganzzahlige Division) und rdx (Rest) gespeichert
+
+Beispiel:
+
+	div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax
+
+ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax.
+Also aufpassen, dass nicht ungewollt noch was in rdx steht.
+Übliches Muster:
+
+	mov rsi, 3
+	mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
+	div rsi    ; Dividiere rax durch 3
+
+### imul reg1 und idiv reg1:
+Definition:
+Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen mit Vorzeichen)
 
 ## Bit-Operationen:
 
@@ -276,68 +341,6 @@ Beispiel:
 
 	ror rax, rdx
 	ror rax, 1
-
-## Arithmetische-Operationen:
-
-### add reg1, value / add reg1, reg2:
-Definition:
-Addiere einen Wert bzw. den Wert eines Registers auf den Wert eines anderen
-Registers.
-
-Beispiel:
-
-	add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
-	add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)
-
-### sub reg1, value / sub reg1, reg2:
-Definition:
-Analog zu `add` jedoch als Subtraktion
-
-Beispiele:
-
-	sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
-	sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)
-
-### neg reg1:
-Definition:
-Negiere den Wert aus dem gegebenen Register (in 2er Komplement).
-
-Beispiel:
-
-	neg rsi ; Negiere den Wert in rsi
-
-### mul reg1:
-Definition:
-Multipliziere den Wert in Register rax mit dem Wert des angegebenen Registers. Das Ergebnis wird in die *beiden (!!!)* Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in rax passiert)
-
-Beispiel:
-
-	mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax
-
-ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden. Falls man das Register rax mit einem bestimmten Wert multiplizieren möchte muss man diesen vorher in ein Register verschieben:
-
-	mov rsi, 3
-	mul rsi    ; Multipliziere rax mit 3
-
-### div reg1:
-Definition:
-Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax) durch den Wert aus dem angegebenen Register. Ergebnis wird in rax (ganzzahlige Division) und rdx (Rest) gespeichert
-
-Beispiel:
-
-	div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax
-
-ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax.
-Also aufpassen, dass nicht ungewollt noch was in rdx steht.
-Übliches Muster:
-
-	mov rsi, 3
-	mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
-	div rsi    ; Dividiere rax durch 3
-
-### imul reg1 und idiv reg1:
-Definition:
-Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen mit Vorzeichen)
 
 ## Vergleiche/Sprünge und Bedinge Sprünge:
 

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -302,11 +302,13 @@ Beispiel:
 
 	div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax
 
-ACHTUNG: Prüfe vor der Division, ob der Wert, der sich in rdx befindet,
-korrekt ist.
-Dort könnte sich 1. ein Wert befinden, der nichts mit der gewollten Rechnung zu
-tun hat und 2. ein Wert drin befinden der nach der Division erhalten bleiben
-sollte.
+ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax.
+Also aufpassen, dass nicht ungewollt noch was in rdx steht.
+Übliches Muster:
+
+	mov rsi, 3
+	mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
+	div rsi    ; Dividiere rax durch 3
 
 ### imul reg (value 1) und idiv reg (value 1):
 Definition:

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -179,6 +179,16 @@ Beispiel under the hood:
 	---------
 	0000 1011 = rdx
 
+### not reg (value 1):
+Definition:
+Invertiert den Wert im ersten Register (alle 0en werden zu 1en und umgekehrt).
+
+Beispiel:
+
+	; rdx = 0011 1011
+	neg rdx
+	; rdx = 1100 0100
+
 ### shl reg (value 1), value / shl reg (value 1), cl
 Definition:
 Shifte den Wert des Registers um $n$ Stellen nach Links.

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -643,3 +643,4 @@ Hierzu findet ihr eine kleine Zusammenfassung von Befehlen zur Ausführung des
 * https://stackoverflow.com/questions/18024672/what-registers-are-preserved-through-a-linux-x86-64-function-call
 * https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html
 * https://cs61.seas.harvard.edu/site/2018/Asm1/
+* https://www.felixcloutier.com/x86/ (all x86 instructions, including detailled description e.g. affected flags)

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -519,29 +519,29 @@ Die Multiplikation bzw. die Division einer Zahl der Basis $b$ mit einer Zahl
 der Form $b^n$ kann als einfache "Verschiebung" um $n$ Stellen betrachtet werden.
 Gucken wir uns dies zuerst im Dezimalsystem mit 10-er Potenzen an:
 
-\begin{align*}
+$$\begin{align*}
 	12 \cdot 10^1 &= 12 \cdot 10   &&= 120 \\
 	12 \cdot 10^2 &= 12 \cdot 100  &&= 1200 \\
 	12 \cdot 10^3 &= 12 \cdot 1000 &&= 12000
-\end{align*}
+\end{align*}$$
 
-\begin{align*}
+$$\begin{align*}
 	12 \div 10^1 &= 12 \div 10   &&= 1.2 \\
 	12 \div 10^2 &= 12 \div 100  &&= 0.12 \\
 	12 \div 10^3 &= 12 \div 1000 &&= 0.012
-\end{align*}
+\end{align*}$$
 
 Im Binärsystem gilt dieses Prinzip natürlich auch:
 
-\begin{align*}
+$$\begin{align*}
 	0011_2 \cdot 2_{10}^1 &= 0011_2 \cdot 2_{10} &&= 0110_2 \\
 	0011_2 \cdot 2_{10}^2 &= 0011_2 \cdot 4_{10} &&= 1100_2
-\end{align*}
+\end{align*}$$
 
-\begin{align*}
+$$\begin{align*}
 	0011_2 \div 2_{10}^1 &= 0011_2 \div 2_{10} &&= 0001(.1000)_2 \\
 	0011_2 \div 2_{10}^2 &= 0011_2 \div 4_{10} &&= 0000(.1100)_2
-\end{align*}
+\end{align*}$$
 
 Hinweise:
 

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -170,27 +170,27 @@ Beispiel:
 
 ### mul reg1:
 Definition:
-Multipliziere den Wert in Register rax mit dem Wert des angegebenen Registers. Das Ergebnis wird in die *beiden (!!!)* Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in rax passiert)
+Multipliziere den Wert in Register `rax` mit dem Wert des angegebenen Registers. Das Ergebnis wird in die **beiden (!!!)** Registern `rax` und `rdx` gespeichert (`rdx`, falls ein Überlauf der Zahl in `rax` passiert)
 
 Beispiel:
 
 	mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax
 
-ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden. Falls man das Register rax mit einem bestimmten Wert multiplizieren möchte muss man diesen vorher in ein Register verschieben:
+ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden. Falls man das Register `rax` mit einem bestimmten Wert multiplizieren möchte muss man diesen vorher in ein Register verschieben:
 
 	mov rsi, 3
 	mul rsi    ; Multipliziere rax mit 3
 
 ### div reg1:
 Definition:
-Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax) durch den Wert aus dem angegebenen Register. Ergebnis wird in rax (ganzzahlige Division) und rdx (Rest) gespeichert
+Dividiere den Wert aus `rdx:rax` (`rdx` konkateniert mit `rax`) durch den Wert aus dem angegebenen Register. Ergebnis wird in `rax` (ganzzahlige Division) und `rdx` (Rest) gespeichert
 
 Beispiel:
 
 	div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax
 
-ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax.
-Also aufpassen, dass nicht ungewollt noch was in rdx steht.
+ACHTUNG: Der Divisor ist nicht nur `rax`, sondern `rdx:rax`.
+Also aufpassen, dass nicht ungewollt noch was in `rdx` steht.
 Übliches Muster:
 
 	mov rsi, 3
@@ -199,7 +199,7 @@ Also aufpassen, dass nicht ungewollt noch was in rdx steht.
 
 ### imul reg1 und idiv reg1:
 Definition:
-Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen mit Vorzeichen)
+Analog zu `mul`/`div`, aber mit signed Zahlen (d.h. Zahlen mit Vorzeichen)
 
 ## Bit-Operationen:
 
@@ -297,7 +297,7 @@ Beispiel under the hood:
 
 	=> rax = 1000 0110
 
-ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register `cl` als
+ACHTUNG: Sowohl `shr`, als auch `shl` nutzen können nur das Register `cl` als
 Registerverschiebungswert nehmen!
 Dies ist dadurch begründet, dass bei der Entwicklung eines x86-Chips nur eine
 Verbindung des Count-Registers (`cl`) angelegt wurde für Verschiebungen.
@@ -431,7 +431,7 @@ Stack-Pointer auf die nächste belegte Adresse zeigt.
 Der Stack wächst, wenn `rsp` kleiner wird. Daher "wächst" der Stack nach 
 unten. (Der Stack ist "full descending".)
 
-WICHTIG: nach dem Funktionsaufruf (also vor dem ret Befehl)
+WICHTIG: nach dem Funktionsaufruf (also vor dem `ret` Befehl)
 muss der Stack-Pointer wieder auf der selben Stelle sein wie zu Beginn des
 Funktionsaufrufs!
 

--- a/Cheat-Sheet.md
+++ b/Cheat-Sheet.md
@@ -110,9 +110,9 @@ Notation: reg = Register (`rax`, ...), imm = Immediate (idR. eine Zahl)
 | [not](#not-reg1)                              | reg1  |          | reg1 = ~reg1 |
 | [shl](#shl-reg1-value--shl-reg1-cl)           | reg1  | `cl`/imm | reg1 = reg1 << `cl`/imm |
 | [shr](#shr-reg1-value--shr-reg1-cl)           | reg1  | `cl`/imm | reg1 = reg1 >> `cl`/imm |
-| [neg](#neg-reg1)                              | reg1  |          | reg1 = -reg1 (2er Komplement) |
 | [add](#add-reg1-value--add-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 + reg2/imm |
 | [sub](#sub-reg1-value--sub-reg1-reg2)         | reg1  | reg2/imm | reg1 = reg1 - reg2/imm |
+| [neg](#neg-reg1)                              | reg1  |          | reg1 = -reg1 (2er Komplement) |
 | [mul](#mul-reg1)                              | reg1  |          | `rdx:rax` = `rax` * reg1 (unsigned) |
 | [div](#div-reg1)                              | reg1  |          | `rax` = `rdx:rax` / reg1 (Rest in `rdx`) |
 | [imul](#imul-reg1-und-idiv-reg1)              | reg1  |          | `rdx:rax` = `rax` * reg1 (signed) |
@@ -279,14 +279,6 @@ Beispiel:
 
 ## Arithmetische-Operationen:
 
-### neg reg1:
-Definition:
-Negiere den Wert aus dem gegebenen Register (in 2er Komplement).
-
-Beispiel:
-
-	neg rsi ; Negiere den Wert in rsi
-
 ### add reg1, value / add reg1, reg2:
 Definition:
 Addiere einen Wert bzw. den Wert eines Registers auf den Wert eines anderen
@@ -305,6 +297,14 @@ Beispiele:
 
 	sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
 	sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)
+
+### neg reg1:
+Definition:
+Negiere den Wert aus dem gegebenen Register (in 2er Komplement).
+
+Beispiel:
+
+	neg rsi ; Negiere den Wert in rsi
 
 ### mul reg1:
 Definition:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PANDOC=pandoc
 all: Cheat-Sheet.html index.html #Cheat-Sheet.pdf
 
 Cheat-Sheet.html: Cheat-Sheet.md styles/style.css
-	$(PANDOC) -f markdown -t html --mathjax --css styles/style.css --standalone -o $@ $<
+	$(PANDOC) -f gfm -t html --mathjax --css styles/style.css --standalone -o $@ $<
 
 Cheat-Sheet.pdf: Cheat-Sheet.md
 	$(PANDOC) -f markdown -t pdf -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ PANDOC=pandoc
 all: Cheat-Sheet.html index.html #Cheat-Sheet.pdf
 
 Cheat-Sheet.html: Cheat-Sheet.md styles/style.css
-	$(PANDOC) -f gfm -t html --mathjax --css styles/style.css --standalone -o $@ $<
+	$(PANDOC) -f gfm -t html --mathjax=https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js --css styles/style.css --standalone -o $@ $<
 
 Cheat-Sheet.pdf: Cheat-Sheet.md
 	$(PANDOC) -f markdown -t pdf -o $@ $<
 
 index.html: Cheat-Sheet.html
-	mv $< $@
+	cp $< $@
 
 .SUFFIXES:
 .SUFFIXES: .html .pdf .md

--- a/index.html
+++ b/index.html
@@ -225,22 +225,22 @@ manuell vor dem Aufruf sichern.</p>
 <td>reg1 = reg1 &gt;&gt; <code>cl</code>/imm</td>
 </tr>
 <tr class="even">
-<td><a href="#neg-reg1">neg</a></td>
-<td>reg1</td>
-<td></td>
-<td>reg1 = -reg1 (2er Komplement)</td>
-</tr>
-<tr class="odd">
 <td><a href="#add-reg1-value--add-reg1-reg2">add</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 = reg1 + reg2/imm</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#sub-reg1-value--sub-reg1-reg2">sub</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 = reg1 - reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#neg-reg1">neg</a></td>
+<td>reg1</td>
+<td></td>
+<td>reg1 = -reg1 (2er Komplement)</td>
 </tr>
 <tr class="odd">
 <td><a href="#mul-reg1">mul</a></td>
@@ -417,11 +417,6 @@ class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <pre><code>ror rax, rdx
 ror rax, 1</code></pre>
 <h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
-<h3 id="neg-reg1">neg reg1:</h3>
-<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
-Komplement).</p>
-<p>Beispiel:</p>
-<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
 <h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
 reg2:</h3>
 <p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
@@ -435,6 +430,11 @@ reg2:</h3>
 <p>Beispiele:</p>
 <pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
 sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
+<h3 id="neg-reg1">neg reg1:</h3>
+<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
+Komplement).</p>
+<p>Beispiel:</p>
+<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
 <h3 id="mul-reg1">mul reg1:</h3>
 <p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
 angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>

--- a/index.html
+++ b/index.html
@@ -665,10 +665,12 @@ durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
 (ganzzahlige Division) und rdx (Rest) gespeichert</p>
 <p>Beispiel:</p>
 <pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
-<p>ACHTUNG: Prüfe vor der Division, ob der Wert, der sich in rdx
-befindet, korrekt ist. Dort könnte sich 1. ein Wert befinden, der nichts
-mit der gewollten Rechnung zu tun hat und 2. ein Wert drin befinden der
-nach der Division erhalten bleiben sollte.</p>
+<p>ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax. Also
+aufpassen, dass nicht ungewollt noch was in rdx steht. Übliches
+Muster:</p>
+<pre><code>mov rsi, 3
+mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
+div rsi    ; Dividiere rax durch 3</code></pre>
 <h3 id="imul-reg-value-1-und-idiv-reg-value-1">imul reg (value 1) und
 idiv reg (value 1):</h3>
 <p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen

--- a/index.html
+++ b/index.html
@@ -683,19 +683,26 @@ class="math inline">\(b\)</span> mit einer Zahl der Form <span
 class="math inline">\(b^n\)</span> kann als einfache "Verschiebung" um
 <span class="math inline">\(n\)</span> Stellen betrachtet werden. Gucken
 wir uns dies zuerst im Dezimalsystem mit 10-er Potenzen an:</p>
-<p>\begin{align*} 12 \cdot 10^1 &amp;= 12 \cdot 10 &amp;&amp;= 120 \ 12
-\cdot 10^2 &amp;= 12 \cdot 100 &amp;&amp;= 1200 \ 12 \cdot 10^3 &amp;=
-12 \cdot 1000 &amp;&amp;= 12000 \end{align*}</p>
-<p>\begin{align*} 12 \div 10^1 &amp;= 12 \div 10 &amp;&amp;= 1.2 \ 12
-\div 10^2 &amp;= 12 \div 100 &amp;&amp;= 0.12 \ 12 \div 10^3 &amp;= 12
-\div 1000 &amp;&amp;= 0.012 \end{align*}</p>
+<p><span class="math display">\[\begin{align*}
+12 \cdot 10^1 &amp;= 12 \cdot 10   &amp;&amp;= 120 \\
+12 \cdot 10^2 &amp;= 12 \cdot 100  &amp;&amp;= 1200 \\
+12 \cdot 10^3 &amp;= 12 \cdot 1000 &amp;&amp;= 12000
+\end{align*}\]</span></p>
+<p><span class="math display">\[\begin{align*}
+12 \div 10^1 &amp;= 12 \div 10   &amp;&amp;= 1.2 \\
+12 \div 10^2 &amp;= 12 \div 100  &amp;&amp;= 0.12 \\
+12 \div 10^3 &amp;= 12 \div 1000 &amp;&amp;= 0.012
+\end{align*}\]</span></p>
 <p>Im Binärsystem gilt dieses Prinzip natürlich auch:</p>
-<p>\begin{align*} 0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10}
-&amp;&amp;= 0110_2 \ 0011_2 \cdot 2_{10}^2 &amp;= 0011_2 \cdot 4_{10}
-&amp;&amp;= 1100_2 \end{align*}</p>
-<p>\begin{align*} 0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10}
-&amp;&amp;= 0001(.1000)<em>2 \ 0011_2 \div 2</em>{10}^2 &amp;= 0011_2
-\div 4_{10} &amp;&amp;= 0000(.1100)_2 \end{align*}</p>
+<p><span class="math display">\[\begin{align*}
+0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10} &amp;&amp;= 0110_2 \\
+0011_2 \cdot 2_{10}^2 &amp;= 0011_2 \cdot 4_{10} &amp;&amp;= 1100_2
+\end{align*}\]</span></p>
+<p><span class="math display">\[\begin{align*}
+0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10} &amp;&amp;= 0001(.1000)_2
+\\
+0011_2 \div 2_{10}^2 &amp;= 0011_2 \div 4_{10} &amp;&amp;= 0000(.1100)_2
+\end{align*}\]</span></p>
 <p>Hinweise:</p>
 <ol type="1">
 <li>Wir geben mit den Subscripts die Basis der Zahlendarstellung

--- a/index.html
+++ b/index.html
@@ -512,58 +512,6 @@ weiteres Register.</p>
 <p>Beispiel:</p>
 <pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
-<h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1),
-value / shl reg (value 1), cl</h3>
-<p>Definition: Shifte den Wert des Registers um <span
-class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
-“rausgeschoben” werden gehen verloren</p>
-<p>Beispiel:</p>
-<pre><code>shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
-shl rax, 1   ; Verschiebe alle Bits</code></pre>
-<p>Beispiel under the hood:</p>
-<pre><code>rax = 1100 0011
-
-shl rax, 1
-
-=&gt; rax = 1000 0110</code></pre>
-<p>ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register
-<code>cl</code> als Registerverschiebungswert nehmen! Dies ist dadurch
-begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
-des Count-Registers (<code>cl</code>) angelegt wurde für
-Verschiebungen.</p>
-<h3 id="shr-reg-value-1-value-shr-reg-value-1-cl">shr reg (value 1),
-value / shr reg (value 1), cl</h3>
-<p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
-Also analog zu <code>shl</code>.</p>
-<p>Beispiel:</p>
-<pre><code>shr rax, cl
-shr rax, 1</code></pre>
-<p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> können
-nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
-Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
-Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
-<h3 id="rol-reg-value-1-value-rol-reg-value-1-reg-value-2">rol reg
-(value 1), value / rol reg (value 1), reg (value 2)</h3>
-<p>Definition: Rotiere die Werte um <span
-class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
-gehen hier die Bits die nach links raus geschoben werden nicht verloren,
-sondern werden rechts hinzugefügt.</p>
-<p>Beispiel:</p>
-<pre><code>rol rax, rdx
-rol rax, 1</code></pre>
-<p>Beispiel under the hood:</p>
-<pre><code>rax = 1100 0100
-
-rol rax, 1
-=&gt; rax = 1000 1001</code></pre>
-<h3 id="ror-reg-value-1-value-ror-reg-value-1-reg-value-2">ror reg
-(value 1), value / ror reg (value 1), reg (value 2)</h3>
-<p>Definition: Rotiere die Werte um <span
-class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
-<code>rol</code></p>
-<p>Beispiel:</p>
-<pre><code>ror rax, rdx
-ror rax, 1</code></pre>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
 <h3 id="and-reg-value-1-value-and-reg-value-1-reg-value-2">and reg
 (value 1), value / and reg (value 1), reg (value 2)</h3>
@@ -621,6 +569,58 @@ xor rdx, 0x8f
 1000 1111
 ---------
 0000 1011 = rdx</code></pre>
+<h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1),
+value / shl reg (value 1), cl</h3>
+<p>Definition: Shifte den Wert des Registers um <span
+class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
+“rausgeschoben” werden gehen verloren</p>
+<p>Beispiel:</p>
+<pre><code>shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
+shl rax, 1   ; Verschiebe alle Bits</code></pre>
+<p>Beispiel under the hood:</p>
+<pre><code>rax = 1100 0011
+
+shl rax, 1
+
+=&gt; rax = 1000 0110</code></pre>
+<p>ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register
+<code>cl</code> als Registerverschiebungswert nehmen! Dies ist dadurch
+begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
+des Count-Registers (<code>cl</code>) angelegt wurde für
+Verschiebungen.</p>
+<h3 id="shr-reg-value-1-value-shr-reg-value-1-cl">shr reg (value 1),
+value / shr reg (value 1), cl</h3>
+<p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
+Also analog zu <code>shl</code>.</p>
+<p>Beispiel:</p>
+<pre><code>shr rax, cl
+shr rax, 1</code></pre>
+<p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> können
+nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
+Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
+Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
+<h3 id="rol-reg-value-1-value-rol-reg-value-1-reg-value-2">rol reg
+(value 1), value / rol reg (value 1), reg (value 2)</h3>
+<p>Definition: Rotiere die Werte um <span
+class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
+gehen hier die Bits die nach links raus geschoben werden nicht verloren,
+sondern werden rechts hinzugefügt.</p>
+<p>Beispiel:</p>
+<pre><code>rol rax, rdx
+rol rax, 1</code></pre>
+<p>Beispiel under the hood:</p>
+<pre><code>rax = 1100 0100
+
+rol rax, 1
+=&gt; rax = 1000 1001</code></pre>
+<h3 id="ror-reg-value-1-value-ror-reg-value-1-reg-value-2">ror reg
+(value 1), value / ror reg (value 1), reg (value 2)</h3>
+<p>Definition: Rotiere die Werte um <span
+class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
+<code>rol</code></p>
+<p>Beispiel:</p>
+<pre><code>ror rax, rdx
+ror rax, 1</code></pre>
 <h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
 <h3 id="neg-reg-value-1">neg reg (value 1):</h3>
 <p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er

--- a/index.html
+++ b/index.html
@@ -20,6 +20,70 @@
       margin: 0 0.8em 0.2em -1.6em;
       vertical-align: middle;
     }
+    /* CSS for syntax highlighting */
+    pre > code.sourceCode { white-space: pre; position: relative; }
+    pre > code.sourceCode > span { line-height: 1.25; }
+    pre > code.sourceCode > span:empty { height: 1.2em; }
+    .sourceCode { overflow: visible; }
+    code.sourceCode > span { color: inherit; text-decoration: inherit; }
+    div.sourceCode { margin: 1em 0; }
+    pre.sourceCode { margin: 0; }
+    @media screen {
+    div.sourceCode { overflow: auto; }
+    }
+    @media print {
+    pre > code.sourceCode { white-space: pre-wrap; }
+    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+    }
+    pre.numberSource code
+      { counter-reset: source-line 0; }
+    pre.numberSource code > span
+      { position: relative; left: -4em; counter-increment: source-line; }
+    pre.numberSource code > span > a:first-child::before
+      { content: counter(source-line);
+        position: relative; left: -1em; text-align: right; vertical-align: baseline;
+        border: none; display: inline-block;
+        -webkit-touch-callout: none; -webkit-user-select: none;
+        -khtml-user-select: none; -moz-user-select: none;
+        -ms-user-select: none; user-select: none;
+        padding: 0 4px; width: 4em;
+        color: #aaaaaa;
+      }
+    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+    div.sourceCode
+      {   }
+    @media screen {
+    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+    }
+    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+    code span.at { color: #7d9029; } /* Attribute */
+    code span.bn { color: #40a070; } /* BaseN */
+    code span.bu { color: #008000; } /* BuiltIn */
+    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+    code span.ch { color: #4070a0; } /* Char */
+    code span.cn { color: #880000; } /* Constant */
+    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+    code span.dt { color: #902000; } /* DataType */
+    code span.dv { color: #40a070; } /* DecVal */
+    code span.er { color: #ff0000; font-weight: bold; } /* Error */
+    code span.ex { } /* Extension */
+    code span.fl { color: #40a070; } /* Float */
+    code span.fu { color: #06287e; } /* Function */
+    code span.im { color: #008000; font-weight: bold; } /* Import */
+    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+    code span.op { color: #666666; } /* Operator */
+    code span.ot { color: #007020; } /* Other */
+    code span.pp { color: #bc7a00; } /* Preprocessor */
+    code span.sc { color: #4070a0; } /* SpecialChar */
+    code span.ss { color: #bb6688; } /* SpecialString */
+    code span.st { color: #4070a0; } /* String */
+    code span.va { color: #19177c; } /* Variable */
+    code span.vs { color: #4070a0; } /* VerbatimString */
+    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
   </style>
   <link rel="stylesheet" href="styles/style.css" />
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
@@ -319,27 +383,31 @@ reg (to), reg (from):</h3>
 <p>Definition: Verschiebe ein Wert bzw. den Wert eines Registers in ein
 weiteres Register.</p>
 <p>Beispiel:</p>
-<pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
-mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
+<div class="sourceCode" id="cb1"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span> <span class="co">; Verschiebe Wert von rdx in rax (ergo rax = rdx)</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">2</span>   <span class="co">; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</span></span></code></pre></div>
 <h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
 <h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
 reg2:</h3>
 <p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
 Wert eines anderen Registers.</p>
 <p>Beispiel:</p>
-<pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
-add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
+<div class="sourceCode" id="cb2"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">add</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span> <span class="co">; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="kw">add</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">2</span>   <span class="co">; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</span></span></code></pre></div>
 <h3 id="sub-reg1-value--sub-reg1-reg2">sub reg1, value / sub reg1,
 reg2:</h3>
 <p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
 <p>Beispiele:</p>
-<pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
-sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
+<div class="sourceCode" id="cb3"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="kw">sub</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span> <span class="co">; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="kw">sub</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">2</span>   <span class="co">; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</span></span></code></pre></div>
 <h3 id="neg-reg1">neg reg1:</h3>
 <p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
 Komplement).</p>
 <p>Beispiel:</p>
-<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
+<div class="sourceCode" id="cb4"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">neg</span> <span class="kw">rsi</span> <span class="co">; Negiere den Wert in rsi</span></span></code></pre></div>
 <h3 id="mul-reg1">mul reg1:</h3>
 <p>Definition: Multipliziere den Wert in Register <code>rax</code> mit
 dem Wert des angegebenen Registers. Das Ergebnis wird in die
@@ -347,26 +415,30 @@ dem Wert des angegebenen Registers. Das Ergebnis wird in die
 <code>rdx</code> gespeichert (<code>rdx</code>, falls ein Überlauf der
 Zahl in <code>rax</code> passiert)</p>
 <p>Beispiel:</p>
-<pre><code>mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</code></pre>
+<div class="sourceCode" id="cb5"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mul</span> <span class="kw">rsi</span> <span class="co">; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</span></span></code></pre></div>
 <p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden.
 Falls man das Register <code>rax</code> mit einem bestimmten Wert
 multiplizieren möchte muss man diesen vorher in ein Register
 verschieben:</p>
-<pre><code>mov rsi, 3
-mul rsi    ; Multipliziere rax mit 3</code></pre>
+<div class="sourceCode" id="cb6"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">3</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="kw">mul</span> <span class="kw">rsi</span>    <span class="co">; Multipliziere rax mit 3</span></span></code></pre></div>
 <h3 id="div-reg1">div reg1:</h3>
 <p>Definition: Dividiere den Wert aus <code>rdx:rax</code>
 (<code>rdx</code> konkateniert mit <code>rax</code>) durch den Wert aus
 dem angegebenen Register. Ergebnis wird in <code>rax</code> (ganzzahlige
 Division) und <code>rdx</code> (Rest) gespeichert</p>
 <p>Beispiel:</p>
-<pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
+<div class="sourceCode" id="cb7"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="kw">div</span> <span class="kw">rsi</span> <span class="co">; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</span></span></code></pre></div>
 <p>ACHTUNG: Der Divisor ist nicht nur <code>rax</code>, sondern
 <code>rdx:rax</code>. Also aufpassen, dass nicht ungewollt noch was in
 <code>rdx</code> steht. Übliches Muster:</p>
-<pre><code>mov rsi, 3
-mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
-div rsi    ; Dividiere rax durch 3</code></pre>
+<div class="sourceCode" id="cb8"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rsi</span><span class="op">,</span> <span class="dv">3</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rdx</span><span class="op">,</span> <span class="dv">0</span> <span class="co">; Sicherstellen, dass obere 64 Bit des Divisors 0 sind</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="kw">div</span> <span class="kw">rsi</span>    <span class="co">; Dividiere rax durch 3</span></span></code></pre></div>
 <h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
 <p>Definition: Analog zu <code>mul</code>/<code>div</code>, aber mit
 signed Zahlen (d.h. Zahlen mit Vorzeichen)</p>
@@ -378,8 +450,9 @@ class="math inline">\(\land\)</span>) mit dem Wert des zweiten
 Parameters auf den Wert des ersten Registers an und speichert das
 Ergebnis im ersten Register.</p>
 <p>Beispiel:</p>
-<pre><code>and rax, rsi ; Verunde den Wert aus rax mit dem Wert aus rsi
-and rax, 0x1 ; Verunde den Wert aus rax mit dem Wert 0x1 (Hexadezimal-Zahl)</code></pre>
+<div class="sourceCode" id="cb9"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="kw">and</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rsi</span> <span class="co">; Verunde den Wert aus rax mit dem Wert aus rsi</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="kw">and</span> <span class="kw">rax</span><span class="op">,</span> <span class="bn">0x1</span> <span class="co">; Verunde den Wert aus rax mit dem Wert 0x1 (Hexadezimal-Zahl)</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rax = 0101 1101
 rsi = 1101 1011
@@ -396,8 +469,9 @@ class="math inline">\(\lor\)</span>) mit dem Wert des zweiten Parameters
 auf das erste Register an und speichert das Ergebnis im ersten
 Register.</p>
 <p>Beispiel:</p>
-<pre><code>or rax, rsi ; Veroder den Wert aus rax mit dem Wert aus rsi
-or rdx, 0xf ; Veroder den Wert aus rdx mit dem Wert 0xf (Binär = 1111)</code></pre>
+<div class="sourceCode" id="cb11"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="kw">or</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rsi</span> <span class="co">; Veroder den Wert aus rax mit dem Wert aus rsi</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="kw">or</span> <span class="kw">rdx</span><span class="op">,</span> <span class="bn">0xf</span> <span class="co">; Veroder den Wert aus rdx mit dem Wert 0xf (Binär = 1111)</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rdx = 0011 1101
 0xf = 0000 1101
@@ -414,8 +488,9 @@ reg2:</h3>
 class="math inline">\(\oplus\)</span>) mit dem Wert des zweiten
 Parameters auf den Wert des ersten Registers an.</p>
 <p>Beispiel:</p>
-<pre><code>xor rax, rsi  ; Wendet XOR auf den Wert von rax mit dem Wert von rsi an
-xor rdx, 0x8f ; Wendet XOR auf den Wert von rdx mit 0x8f (Binär = 1000 1111) an</code></pre>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">xor</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rsi</span>  <span class="co">; Wendet XOR auf den Wert von rax mit dem Wert von rsi an</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="kw">xor</span> <span class="kw">rdx</span><span class="op">,</span> <span class="bn">0x8f</span> <span class="co">; Wendet XOR auf den Wert von rdx mit 0x8f (Binär = 1000 1111) an</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rdx  = 0011 1011
 0xff = 1000 1111
@@ -430,16 +505,18 @@ xor rdx, 0x8f
 <p>Definition: Invertiert den Wert im ersten Register (alle 0en werden
 zu 1en und umgekehrt).</p>
 <p>Beispiel:</p>
-<pre><code>; rdx = 0011 1011
-neg rdx
-; rdx = 1100 0100</code></pre>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="co">; rdx = 0011 1011</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="kw">neg</span> <span class="kw">rdx</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="co">; rdx = 1100 0100</span></span></code></pre></div>
 <h3 id="shl-reg1-value--shl-reg1-cl">shl reg1, value / shl reg1, cl</h3>
 <p>Definition: Shifte den Wert des Registers um <span
 class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
 "rausgeschoben" werden gehen verloren</p>
 <p>Beispiel:</p>
-<pre><code>shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
-shl rax, 1   ; Verschiebe alle Bits</code></pre>
+<div class="sourceCode" id="cb16"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">shl</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">cl</span> <span class="co">; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a><span class="kw">shl</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span>   <span class="co">; Verschiebe alle Bits</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rax = 1100 0011
 
@@ -455,8 +532,9 @@ angelegt wurde für Verschiebungen.</p>
 <p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
 Also analog zu <code>shl</code>.</p>
 <p>Beispiel:</p>
-<pre><code>shr rax, cl
-shr rax, 1</code></pre>
+<div class="sourceCode" id="cb18"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="kw">shr</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">cl</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="kw">shr</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span></span></code></pre></div>
 <p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> können
 nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
 Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
@@ -468,8 +546,9 @@ class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
 gehen hier die Bits die nach links raus geschoben werden nicht verloren,
 sondern werden rechts hinzugefügt.</p>
 <p>Beispiel:</p>
-<pre><code>rol rax, rdx
-rol rax, 1</code></pre>
+<div class="sourceCode" id="cb19"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="kw">rol</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="kw">rol</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span></span></code></pre></div>
 <p>Beispiel under the hood:</p>
 <pre><code>rax = 1100 0100
 
@@ -481,8 +560,9 @@ reg2</h3>
 class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <code>rol</code></p>
 <p>Beispiel:</p>
-<pre><code>ror rax, rdx
-ror rax, 1</code></pre>
+<div class="sourceCode" id="cb21"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="kw">ror</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rdx</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="kw">ror</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span></span></code></pre></div>
 <h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und
 Bedinge Sprünge:</h2>
 <h3 id="cmp-reg1-value--cmp-reg1-reg2">cmp reg1, value / cmp reg1,
@@ -491,20 +571,22 @@ reg2:</h3>
 eines weiteren Registers. Diese Operation setzt Bits im Flag-Register
 die später für Bedingte-Sprünge verwendet werden könnten</p>
 <p>Beispiel:</p>
-<pre><code>cmp rax, rsi ; Vergleiche rax mit dem Wert aus rsi
-cmp rax, 2   ; Vergleiche rax mit dem Wert 2</code></pre>
+<div class="sourceCode" id="cb22"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="kw">cmp</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rsi</span> <span class="co">; Vergleiche rax mit dem Wert aus rsi</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a><span class="kw">cmp</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">2</span>   <span class="co">; Vergleiche rax mit dem Wert 2</span></span></code></pre></div>
 <h3 id="jmp-some_label">jmp some_label:</h3>
 <p>Definition: Setze den Programm Counter (PC, bzw. <code>rip</code>)
 auf die Adresse des angegebenen Labels (<code>some_label</code>). An
 Stelle eines Labels kann auch direkt eine Zahl als Adresse genutzt
 werden (<code>jmp 100</code>).</p>
 <p>Beispiel:</p>
-<pre><code>; [...]
-jmp .some_label
-; [...]
-
-.some_label:
-; [Do something]</code></pre>
+<div class="sourceCode" id="cb23"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="co">; [...]</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a><span class="cf">jmp</span> <span class="fu">.some_label</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a><span class="co">; [...]</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a><span class="fu">.some_label:</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a><span class="co">; [Do something]</span></span></code></pre></div>
 <h3 id="jx-some_label">j<em>X</em> some_label:</h3>
 <p>(<em>X</em> wird durch eine von vielen Bezeichnungen ersetzt:
 <code>je</code>, <code>jne</code>, ...)</p>
@@ -572,14 +654,15 @@ oben nur mit equal</td>
 </tbody>
 </table>
 <p>Beispiele:</p>
-<pre><code>; [...]
-cmp rax, 2
-jl .some_label
-; execute here if rax &gt;= 2
-; [...]
-
-.some_label:
-; execute here if rax &lt; 2</code></pre>
+<div class="sourceCode" id="cb24"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="co">; [...]</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a><span class="kw">cmp</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">2</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a><span class="cf">jl</span> <span class="fu">.some_label</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a><span class="co">; execute here if rax &gt;= 2</span></span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a><span class="co">; [...]</span></span>
+<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a><span class="fu">.some_label:</span></span>
+<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a><span class="co">; execute here if rax &lt; 2</span></span></code></pre></div>
 <h3 id="test-reg1-value--test-reg1-reg2">test reg1, value / test reg1,
 reg2:</h3>
 <p>Definition: Führt ein logisches UND (<span
@@ -620,17 +703,19 @@ Beginn des Funktionsaufrufs!</p>
 <code>push</code>-Befehl. Dieser legt dann den Wert des angegebenen
 Registers auf den Stack ab und aktualisiert den Stack-Pointer.</p>
 <p>Beispiel:</p>
-<pre><code>push rax
-push esi
-push cl</code></pre>
+<div class="sourceCode" id="cb25"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="kw">push</span> <span class="kw">rax</span></span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a><span class="kw">push</span> <span class="kw">esi</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a><span class="kw">push</span> <span class="kw">cl</span></span></code></pre></div>
 <h3 id="pop-reg">pop reg:</h3>
 <p>Definition: Um Daten vom Stack wieder zu nehmen nutzt man den
 <code>pop</code>-Befehl. Dieser lädt das Datum welches zuletzt auf den
 Stack gelegt wurde und speichert es in das jeweilige Register.</p>
 <p>Beispiel:</p>
-<pre><code>pop cl
-pop esi
-pop rax</code></pre>
+<div class="sourceCode" id="cb26"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="kw">pop</span> <span class="kw">cl</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a><span class="kw">pop</span> <span class="kw">esi</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a><span class="kw">pop</span> <span class="kw">rax</span></span></code></pre></div>
 <p>WICHTIG: Es muss in umgekehrter Reigenfolge gepoppt werden wie die
 Elemente gepusht wurde. Dies ist der Fall wegen der LIFO-Struktur des
 Stacks!</p>
@@ -647,30 +732,32 @@ zur jeweiligen Adresse durchgeführt wird.</p>
 dass ihr die Calling-Convention beachtet (bspw. Eingaberegister füllen
 oder jeweilige Register sichern)</p>
 <p>Beispiel:</p>
-<pre><code>some_function:
-    ...
-    call some_other_function
-    ; ret der subroutine macht hier weiter
-    ...
-
-some_other_function:
-    ...
-    ret</code></pre>
+<div class="sourceCode" id="cb27"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">some_function:</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">call</span> some_other_function</span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>    <span class="co">; ret der subroutine macht hier weiter</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a><span class="fu">some_other_function:</span></span>
+<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">ret</span></span></code></pre></div>
 <h1 id="assembly-tricks">Assembly-Tricks:</h1>
 <h3 id="ein-register-auf-0-setzen-clean-oder-bereinigen">Ein Register
 auf 0 setzen ("clean" oder "bereinigen")</h3>
 <p>Um den Wert eines Registers auf 0 zu setzen könnt ihr einfach die
 Zahl 0 in das jeweilige Register setzen:</p>
-<pre><code>mov rax, 0 ; Setze rax = 0</code></pre>
+<div class="sourceCode" id="cb28"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="kw">mov</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">0</span> <span class="co">; Setze rax = 0</span></span></code></pre></div>
 <p>Optional hierzu könnt ihr die <code>xor</code>-Instruktion nutzen. Da
 XOR ein gegebenen Bit auf 0 setzt, gdw. beide Register-Einträge 0 sind,
 ODER beide Registereinträge 1 sind folgt daraus, dass ein XOR mit dem
 selben Wert das jeweilige Register auf 0 setzen wird. Dies hat also den
 selben Effekt wie ein <code>mov</code> Befehl und <em>kann</em> unter
 Umständen effizienter sein (konkret ist die Codierungslänge kürzer).</p>
-<pre><code>xor rax, rax ; Setze rax = 0
-
-e.g rax = 1101 1111
+<div class="sourceCode" id="cb29"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="kw">xor</span> <span class="kw">rax</span><span class="op">,</span> <span class="kw">rax</span> <span class="co">; Setze rax = 0</span></span></code></pre></div>
+<pre><code>e.g rax = 1101 1111
 
 xor rax, rax
 =&gt;
@@ -718,11 +805,12 @@ ganzzahlige Division möglich.</li>
 Registers mit einem Wert der Form <span
 class="math inline">\(2^n\)</span> als <span
 class="math inline">\(n\)</span>-Fachen-Shift implementieren:</p>
-<pre><code>shl rax, 1 ; rax = rax*2
-shl rax, 2 ; rax = rax*4
-
-shr rax, 1 ; rax = rax/2 (ganzzahlig)
-shr rax, 2 ; rax = rax/4 (ganzzahlig)</code></pre>
+<div class="sourceCode" id="cb31"><pre
+class="sourceCode nasm"><code class="sourceCode nasm"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">shl</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span> <span class="co">; rax = rax*2</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="kw">shl</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">2</span> <span class="co">; rax = rax*4</span></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a><span class="kw">shr</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">1</span> <span class="co">; rax = rax/2 (ganzzahlig)</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="kw">shr</span> <span class="kw">rax</span><span class="op">,</span> <span class="dv">2</span> <span class="co">; rax = rax/4 (ganzzahlig)</span></span></code></pre></div>
 <h1 id="ssh-and-working-on-andorra">SSH and working on Andorra</h1>
 <h2 id="verbinden">Verbinden</h2>
 <p>Als Referenzsystem für unseren Code nutzen wir die

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   </style>
   <link rel="stylesheet" href="styles/style.css" />
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script src="/usr/share/javascript/mathjax/MathJax.js"
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js"
   type="text/javascript"></script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -341,32 +341,35 @@ Komplement).</p>
 <p>Beispiel:</p>
 <pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
 <h3 id="mul-reg1">mul reg1:</h3>
-<p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
-angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>
-Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in
-rax passiert)</p>
+<p>Definition: Multipliziere den Wert in Register <code>rax</code> mit
+dem Wert des angegebenen Registers. Das Ergebnis wird in die
+<strong>beiden (!!!)</strong> Registern <code>rax</code> und
+<code>rdx</code> gespeichert (<code>rdx</code>, falls ein Überlauf der
+Zahl in <code>rax</code> passiert)</p>
 <p>Beispiel:</p>
 <pre><code>mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</code></pre>
 <p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden.
-Falls man das Register rax mit einem bestimmten Wert multiplizieren
-möchte muss man diesen vorher in ein Register verschieben:</p>
+Falls man das Register <code>rax</code> mit einem bestimmten Wert
+multiplizieren möchte muss man diesen vorher in ein Register
+verschieben:</p>
 <pre><code>mov rsi, 3
 mul rsi    ; Multipliziere rax mit 3</code></pre>
 <h3 id="div-reg1">div reg1:</h3>
-<p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax)
-durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
-(ganzzahlige Division) und rdx (Rest) gespeichert</p>
+<p>Definition: Dividiere den Wert aus <code>rdx:rax</code>
+(<code>rdx</code> konkateniert mit <code>rax</code>) durch den Wert aus
+dem angegebenen Register. Ergebnis wird in <code>rax</code> (ganzzahlige
+Division) und <code>rdx</code> (Rest) gespeichert</p>
 <p>Beispiel:</p>
 <pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
-<p>ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax. Also
-aufpassen, dass nicht ungewollt noch was in rdx steht. Übliches
-Muster:</p>
+<p>ACHTUNG: Der Divisor ist nicht nur <code>rax</code>, sondern
+<code>rdx:rax</code>. Also aufpassen, dass nicht ungewollt noch was in
+<code>rdx</code> steht. Übliches Muster:</p>
 <pre><code>mov rsi, 3
 mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
 div rsi    ; Dividiere rax durch 3</code></pre>
 <h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
-<p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen
-mit Vorzeichen)</p>
+<p>Definition: Analog zu <code>mul</code>/<code>div</code>, aber mit
+signed Zahlen (d.h. Zahlen mit Vorzeichen)</p>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
 <h3 id="and-reg1-value--and-reg1-reg2">and reg1, value / and reg1,
 reg2</h3>
@@ -443,11 +446,11 @@ shl rax, 1   ; Verschiebe alle Bits</code></pre>
 shl rax, 1
 
 =&gt; rax = 1000 0110</code></pre>
-<p>ACHTUNG: Sowohl shr, als auch shl nutzen können nur das Register
-<code>cl</code> als Registerverschiebungswert nehmen! Dies ist dadurch
-begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
-des Count-Registers (<code>cl</code>) angelegt wurde für
-Verschiebungen.</p>
+<p>ACHTUNG: Sowohl <code>shr</code>, als auch <code>shl</code> nutzen
+können nur das Register <code>cl</code> als Registerverschiebungswert
+nehmen! Dies ist dadurch begründet, dass bei der Entwicklung eines
+x86-Chips nur eine Verbindung des Count-Registers (<code>cl</code>)
+angelegt wurde für Verschiebungen.</p>
 <h3 id="shr-reg1-value--shr-reg1-cl">shr reg1, value / shr reg1, cl</h3>
 <p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
 Also analog zu <code>shl</code>.</p>
@@ -609,9 +612,9 @@ den Beginn des Stacks währenddessen der Stack-Pointer auf die nächste
 belegte Adresse zeigt. Der Stack wächst, wenn <code>rsp</code> kleiner
 wird. Daher "wächst" der Stack nach unten. (Der Stack ist "full
 descending".)</p>
-<p>WICHTIG: nach dem Funktionsaufruf (also vor dem ret Befehl) muss der
-Stack-Pointer wieder auf der selben Stelle sein wie zu Beginn des
-Funktionsaufrufs!</p>
+<p>WICHTIG: nach dem Funktionsaufruf (also vor dem <code>ret</code>
+Befehl) muss der Stack-Pointer wieder auf der selben Stelle sein wie zu
+Beginn des Funktionsaufrufs!</p>
 <h3 id="push-reg">push reg:</h3>
 <p>Definition: Um Daten auf den Stack zu legen nutzt man den
 <code>push</code>-Befehl. Dieser legt dann den Wert des angegebenen

--- a/index.html
+++ b/index.html
@@ -697,10 +697,9 @@ jmp .some_label
 
 .some_label:
 ; [Do something]</code></pre>
-<h3
-id="jl-some_label-jb-some_label-jg-some_label-ja-some_label-je-some_label-jne-some_label">jl
-some_label / jb some_label / jg some_label / ja some_label / je
-some_label / jne some_label …</h3>
+<h3 id="jx-some_label">j<em>X</em> some_label:</h3>
+<p>(<em>X</em> wird durch eine von vielen Bezeichnungen ersetzt:
+<code>je</code>, <code>jne</code>, …)</p>
 <p>Definition: Springe, wenn bestimmte Bits im Flag-Register gesetzt
 sind. Dies wird in der Regel in Kombination mit einer
 Vergleich-Operation genutzt, um diese Bits zu setzen.</p>

--- a/index.html
+++ b/index.html
@@ -8,18 +8,23 @@
   <style>
     code{white-space: pre-wrap;}
     span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
     div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
   </style>
   <link rel="stylesheet" href="styles/style.css" />
-  <script
-  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js"
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script src="/usr/share/javascript/mathjax/MathJax.js"
   type="text/javascript"></script>
-  <!--[if lt IE 9]>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-  <![endif]-->
 </head>
 <body>
 <header id="title-block-header">
@@ -774,8 +779,8 @@ wird verworfen, jedoch werden folgende Flags gesetzt:</p>
 Zahl handelt,</li>
 <li><code>zf</code>: zero flag, gibt an ob das Ergebnis die Zahl 0
 repräsentiert,</li>
-<li><code>pf</code>: parity flag, gibt an ob das Ergebnis
-gerade/ungerade ist, also gdw., ob das letzte Bit gesetzt ist.</li>
+<li><code>pf</code>: parity flag, gibt an ob die Anzahl an gesetzten
+Bits im niedrigsten Byte gerade ist.</li>
 </ul>
 <p>Anmerkungen:</p>
 <ul>
@@ -792,7 +797,9 @@ gibt Assembly Instruktionen um auf diesen direkt zuzugreifen. Zusätzlich
 werden zwei Werte vorgehalten: der (Stack-)Base-Pointer (oder
 Frame-Pointer) und der Stack-Pointer. Der Base-Pointer zeigt immer auf
 den Beginn des Stacks währenddessen der Stack-Pointer auf die nächste
-freie Adresse zeigt.</p>
+belegte Adresse zeigt. Der Stack wächst, wenn <code>rsp</code> kleiner
+wird. Daher “wächst” der Stack nach unten. (Der Stack ist “full
+descending”.)</p>
 <p>WICHTIG: nach dem Funktionsaufruf (also vor dem ret Befehl) muss der
 Stack-Pointer wieder auf der selben Stelle sein wie zu Beginn des
 Funktionsaufrufs!</p>

--- a/index.html
+++ b/index.html
@@ -34,401 +34,67 @@
 <h1 id="register">Register</h1>
 <table style="background-color: #f8f9fa;color: #202122;margin: 1em 0;border: 1px solid #a2a9b1;border-collapse: collapse;">
 <tbody>
-<tr>
-<th>
-Register
-</th>
-<th style="width: 12%;" colspan="8">
-Accumulator
-</th>
-<th style="width: 12%;" colspan="8">
-Counter
-</th>
-<th style="width: 12%;" colspan="8">
-Data
-</th>
-<th style="width: 12%;" colspan="8">
-Base
-</th>
-<th style="width: 12%;" colspan="8">
-Stack Pointer
-</th>
-<th style="width: 12%;" colspan="8">
-Stack Base Pointer
-</th>
-<th style="width: 12%;" colspan="8">
-Source
-</th>
-<th style="width: 12%;" colspan="8">
-Destination
-</th>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-64-bit
-</th>
-<td colspan="8">
-rax
-</td>
-<td colspan="8">
-rcx
-</td>
-<td colspan="8">
-rdx
-</td>
-<td colspan="8">
-rbx
-</td>
-<td colspan="8">
-rsp
-</td>
-<td colspan="8">
-rbp
-</td>
-<td colspan="8">
-rsi
-</td>
-<td colspan="8">
-rdi
-</td>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-32-bit
-</th>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-eax
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-ecx
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-edx
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-ebx
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-esp
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-ebp
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-esi
-</td>
-<td style="width: 6%;" colspan="4">
-</td>
-<td style="width: 6%;" colspan="4">
-edi
-</td>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-16-bit
-</th>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-ax
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-cx
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-dx
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-bx
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-sp
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-bp
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-si
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 3%;" colspan="2">
-di
-</td>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-8-bit
-</th>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 1.5%;" colspan="1">
-ah
-</td>
-<td style="width: 1.5%;" colspan="1">
-al
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 1.5%;" colspan="1">
-ch
-</td>
-<td style="width: 1.5%;" colspan="1">
-cl
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 1.5%;" colspan="1">
-dh
-</td>
-<td style="width: 1.5%;" colspan="1">
-dl
-</td>
-<td style="width: 9%;" colspan="6">
-</td>
-<td style="width: 1.5%;" colspan="1">
-bh
-</td>
-<td style="width: 1.5%;" colspan="1">
-bl
-</td>
-<td style="width: 9%;" colspan="7">
-</td>
-<td style="width: 1.5%;" colspan="1">
-spl
-</td>
-<td style="width: 9%;" colspan="7">
-</td>
-<td style="width: 1.5%;" colspan="1">
-bpl
-</td>
-<td style="width: 9%;" colspan="7">
-</td>
-<td style="width: 1.5%;" colspan="1">
-sil
-</td>
-<td style="width: 9%;" colspan="7">
-</td>
-<td style="width: 1.5%;" colspan="1">
-dil
-</td>
-</tr>
+  <tr><th>Register</th><th style="width: 12%;" colspan="8">Accumulator</th><th style="width: 12%;" colspan="8">Counter</th><th style="width: 12%;" colspan="8">Data</th><th style="width: 12%;" colspan="8">Base</th><th style="width: 12%;" colspan="8">Stack Pointer</th><th style="width: 12%;" colspan="8">Stack Base Pointer</th><th style="width: 12%;" colspan="8">Source</th><th style="width: 12%;" colspan="8">Destination</th></tr>
+  <tr style="text-align: center;"><th scope="row">64-bit</th><td colspan="8">rax</td><td colspan="8">rcx</td><td colspan="8">rdx</td><td colspan="8">rbx</td><td colspan="8">rsp</td><td colspan="8">rbp</td><td colspan="8">rsi</td><td colspan="8">rdi</td></tr>
+  <tr style="text-align: center;"><th scope="row">32-bit</th><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">eax</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">ecx</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">edx</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">ebx</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">esp</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">ebp</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">esi</td><td style="width: 6%;" colspan="4"></td><td style="width: 6%;" colspan="4">edi</td></tr>
+  <tr style="text-align: center;"><th scope="row">16-bit</th><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">ax</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">cx</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">dx</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">bx</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">sp</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">bp</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">si</td><td style="width: 9%;" colspan="6"></td><td style="width: 3%;" colspan="2">di</td></tr>
+  <tr style="text-align: center;"><th scope="row">8-bit</th><td style="width: 9%;" colspan="6"></td><td style="width: 1.5%;" colspan="1">ah</td><td style="width: 1.5%;" colspan="1">al</td><td style="width: 9%;" colspan="6"></td><td style="width: 1.5%;" colspan="1">ch</td><td style="width: 1.5%;" colspan="1">cl</td><td style="width: 9%;" colspan="6"></td><td style="width: 1.5%;" colspan="1">dh</td><td style="width: 1.5%;" colspan="1">dl</td><td style="width: 9%;" colspan="6"></td><td style="width: 1.5%;" colspan="1">bh</td><td style="width: 1.5%;" colspan="1">bl</td><td style="width: 9%;" colspan="7"></td><td style="width: 1.5%;" colspan="1">spl</td><td style="width: 9%;" colspan="7"></td><td style="width: 1.5%;" colspan="1">bpl</td><td style="width: 9%;" colspan="7"></td><td style="width: 1.5%;" colspan="1">sil</td><td style="width: 9%;" colspan="7"></td><td style="width: 1.5%;" colspan="1">dil</td></tr>
 </tbody>
-<caption>
-</caption>
+<caption></caption>
 </table>
+
 <h2 id="verbotene-register">Verbotene Register</h2>
 <p>Folgende Register sollten nicht benutzt werden. Das schließt die
 kleineren Register mit ein.</p>
 <table style="background-color: #f8f9fa;color: #202122;margin: 1em 0;border: 1px solid #a2a9b1;border-collapse: collapse;">
 <tbody>
-<tr>
-<th>
-Register
-</th>
-<th>
-Zugehörig
-</th>
-<th>
-Grund
-</th>
-</tr>
-<tr>
-<td>
-rbp
-</td>
-<td>
-ebp, bp, bpl
-</td>
-<td>
-Pointer zur vorherigen Stackframe.
-</td>
-</tr>
-<tr>
-<td>
-rsp
-</td>
-<td>
-esp, sp, sple
-</td>
-<td>
-Markiert die Position des obersten Eintrags im Stack.
-</td>
-</tr>
-<tr>
-<td>
-rbx
-</td>
-<td>
-ebx, bx, bh, bl
-</td>
-<td>
-Vorgabe, wird direkt für die Steuerung des Programmablaufs genutzt.
-</td>
-</tr>
-<tr>
-<td>
-r12
-</td>
-<td>
-r12d, r12w, r12b
-</td>
-<td>
-Reserviert für interne Abläufe. Kann genutzt werden, falls der Wert
-manuell gespeichert wurde.
-</td>
-</tr>
-<tr>
-<td>
-r13
-</td>
-<td>
-r13d, r13w, r13b
-</td>
-<td>
-Reserviert laut Standard.
-</td>
-</tr>
-<tr>
-<td>
-r14
-</td>
-<td>
-r14d, r14w, r14b
-</td>
-<td>
-Reserviert laut Standard.
-</td>
-</tr>
-<tr>
-<td>
-r15
-</td>
-<td>
-r15d, r15w, r15b
-</td>
-<td>
-Reserviert laut Standard.
-</td>
-</tr>
-<tr>
-<td>
-rip
-</td>
-<td>
-ip
-</td>
-<td>
-Program counter.
-</td>
-</tr>
-<tr>
-<td>
-rflags
-</td>
-<td>
-eflags, flags
-</td>
-<td>
-Regelt zero flag, carry flag, etc.
-</td>
-</tr>
+<tr><th>Register</th><th>Zugehörig</th><th>Grund</th></tr>
+<tr><td>rbp</td><td>ebp, bp, bpl</td><td>Pointer zur vorherigen Stackframe.</td></tr>
+<tr><td>rsp</td><td>esp, sp, sple</td><td>Markiert die Position des obersten Eintrags im Stack.</td></tr>
+<tr><td>rbx</td><td>ebx, bx, bh, bl</td><td>Vorgabe, wird direkt für die Steuerung des Programmablaufs genutzt.</td></tr>
+<tr><td>r12</td><td>r12d, r12w, r12b</td><td>Reserviert für interne Abläufe. Kann genutzt werden, falls der Wert manuell gespeichert wurde.</td></tr>
+<tr><td>r13</td><td>r13d, r13w, r13b</td><td>Reserviert laut Standard.</td></tr>
+<tr><td>r14</td><td>r14d, r14w, r14b</td><td>Reserviert laut Standard.</td></tr>
+<tr><td>r15</td><td>r15d, r15w, r15b</td><td>Reserviert laut Standard.</td></tr>
+<tr><td>rip</td><td>ip</td><td>Program counter.</td></tr>
+<tr><td>rflags</td><td>eflags, flags</td><td>Regelt zero flag, carry flag, etc.</td></tr>
 </tbody>
-<caption>
-</caption>
+<caption></caption>
 </table>
+
 <h2 id="eingabe-register">Eingabe-Register</h2>
 <p>Funktionsparameter werden in folgenden Registern übermittelt:</p>
 <table>
 <tbody>
-<tr style="text-align: center;">
-<th scope="row">
-Parameter Nummer
-</th>
-<td colspan="8">
-1
-</td>
-<td colspan="8">
-2
-</td>
-<td colspan="8">
-3
-</td>
-<td colspan="8">
-4
-</td>
-<td colspan="8">
-5
-</td>
-<td colspan="8">
-6
-</td>
-<td colspan="8">
-7+
-</td>
-</tr>
-<tr style="text-align: center;">
-<th scope="row">
-Register
-</th>
-<td colspan="8">
-rdi
-</td>
-<td colspan="8">
-rsi
-</td>
-<td colspan="8">
-rdx
-</td>
-<td colspan="8">
-rcx
-</td>
-<td colspan="8">
-r8
-</td>
-<td colspan="8">
-r9
-</td>
-<td colspan="8">
-Stack
-</td>
-</tr>
+  <tr style="text-align: center;"><th scope="row">Parameter Nummer</th>
+  <td colspan="8">1</td>
+  <td colspan="8">2</td>
+  <td colspan="8">3</td>
+  <td colspan="8">4</td>
+  <td colspan="8">5</td>
+  <td colspan="8">6</td>
+  <td colspan="8">7+</td>
+  </tr>
+  <tr style="text-align: center;"><th scope="row">Register</th>
+  <td colspan="8">rdi</td>
+  <td colspan="8">rsi</td>
+  <td colspan="8">rdx</td>
+  <td colspan="8">rcx</td>
+  <td colspan="8">r8</td>
+  <td colspan="8">r9</td>
+  <td colspan="8">Stack</td>
+  </tr>
 </tbody>
 </table>
+
 <h2 id="rückgabe-register">Rückgabe-Register</h2>
 <p>Der Rückgabewert einer Funktion steht im <code>rax</code> Register.
 Achtet dabei darauf, dass ihr euer Ergebnis immer ins rax Register
 schreibt.</p>
 <p>Für Floating-Point-Zahlen steht das Ergebnis einer Funktion im
 <code>xmm0</code> Register.</p>
-<h2 id="volatile--vs.-non-volatile-register">Volatile-
-vs. Non-Volatile-Register</h2>
+<h2 id="volatile--vs-non-volatile-register">Volatile- vs.
+Non-Volatile-Register</h2>
 <p>Nach Calling-Convention werden die Register in 2 Kategorien
 eingeteilt: Volatile und Non-Volatile. Non-Volatile-Register behalten,
 nach Calling-Convention, nach einem Funktionsaufruf ihren Wert. D.h. wir
@@ -505,7 +171,7 @@ manuell vor dem Aufruf sichern.</p>
 </table>
 <h1 id="befehle">Befehle</h1>
 <h2 id="bewegen-von-daten">Bewegen von Daten:</h2>
-<h3 id="mov-reg-to-value-mov-reg-to-reg-from">mov reg (to), value / mov
+<h3 id="mov-reg-to-value--mov-reg-to-reg-from">mov reg (to), value / mov
 reg (to), reg (from):</h3>
 <p>Definition: Verschiebe ein Wert bzw. den Wert eines Registers in ein
 weiteres Register.</p>
@@ -513,7 +179,7 @@ weiteres Register.</p>
 <pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
-<h3 id="and-reg-value-1-value-and-reg-value-1-reg-value-2">and reg
+<h3 id="and-reg-value-1-value--and-reg-value-1-reg-value-2">and reg
 (value 1), value / and reg (value 1), reg (value 2)</h3>
 <p>Definition: Wendet das logische UND (<span
 class="math inline">\(\land\)</span>) mit dem Wert des zweiten
@@ -532,7 +198,7 @@ and rax, rsi = 0101 1101 and 1101 1011
 1001 1011
 ---------
 0001 1001 = rax</code></pre>
-<h3 id="or-reg-value-1-value-or-reg-value-1-reg-value-2">or reg (value
+<h3 id="or-reg-value-1-value--or-reg-value-1-reg-value-2">or reg (value
 1), value / or reg (value 1), reg (value 2)</h3>
 <p>Definition: Wende das logische ODER (<span
 class="math inline">\(\lor\)</span>) mit dem Wert des zweiten Parameters
@@ -551,7 +217,7 @@ or rdx, 0xf = 0011 1101 or 0000 1101
 0000 1101
 ---------
 0011 1101 = rdx</code></pre>
-<h3 id="xor-reg-value-1-value-xor-reg-value-1-reg-value-2">xor reg
+<h3 id="xor-reg-value-1-value--xor-reg-value-1-reg-value-2">xor reg
 (value 1), value / xor reg (value 1), reg (value 2):</h3>
 <p>Definition: Wendet das logische XOR (<span
 class="math inline">\(\oplus\)</span>) mit dem Wert des zweiten
@@ -576,11 +242,11 @@ zu 1en und umgekehrt).</p>
 <pre><code>; rdx = 0011 1011
 neg rdx
 ; rdx = 1100 0100</code></pre>
-<h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1),
+<h3 id="shl-reg-value-1-value--shl-reg-value-1-cl">shl reg (value 1),
 value / shl reg (value 1), cl</h3>
 <p>Definition: Shifte den Wert des Registers um <span
 class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
-“rausgeschoben” werden gehen verloren</p>
+"rausgeschoben" werden gehen verloren</p>
 <p>Beispiel:</p>
 <pre><code>shl rax, cl ; Verschiebe alle Bits von rax um n-Stellen (Entsprechend des Wertes aus cl)
 shl rax, 1   ; Verschiebe alle Bits</code></pre>
@@ -595,7 +261,7 @@ shl rax, 1
 begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
 des Count-Registers (<code>cl</code>) angelegt wurde für
 Verschiebungen.</p>
-<h3 id="shr-reg-value-1-value-shr-reg-value-1-cl">shr reg (value 1),
+<h3 id="shr-reg-value-1-value--shr-reg-value-1-cl">shr reg (value 1),
 value / shr reg (value 1), cl</h3>
 <p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
 Also analog zu <code>shl</code>.</p>
@@ -606,7 +272,7 @@ shr rax, 1</code></pre>
 nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
 Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
 Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
-<h3 id="rol-reg-value-1-value-rol-reg-value-1-reg-value-2">rol reg
+<h3 id="rol-reg-value-1-value--rol-reg-value-1-reg-value-2">rol reg
 (value 1), value / rol reg (value 1), reg (value 2)</h3>
 <p>Definition: Rotiere die Werte um <span
 class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
@@ -620,7 +286,7 @@ rol rax, 1</code></pre>
 
 rol rax, 1
 =&gt; rax = 1000 1001</code></pre>
-<h3 id="ror-reg-value-1-value-ror-reg-value-1-reg-value-2">ror reg
+<h3 id="ror-reg-value-1-value--ror-reg-value-1-reg-value-2">ror reg
 (value 1), value / ror reg (value 1), reg (value 2)</h3>
 <p>Definition: Rotiere die Werte um <span
 class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
@@ -634,14 +300,14 @@ ror rax, 1</code></pre>
 Komplement).</p>
 <p>Beispiel:</p>
 <pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
-<h3 id="add-reg-value-1-value-add-reg-value-1-reg-value-2">add reg
+<h3 id="add-reg-value-1-value--add-reg-value-1-reg-value-2">add reg
 (value 1), value / add reg (value 1), reg (value 2):</h3>
 <p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
 Wert eines anderen Registers.</p>
 <p>Beispiel:</p>
 <pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
 add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
-<h3 id="sub-reg-value-1-value-sub-reg-value-1-reg-value-2">sub reg
+<h3 id="sub-reg-value-1-value--sub-reg-value-1-reg-value-2">sub reg
 (value 1), value / sub reg (value 1), reg (value 2):</h3>
 <p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
 <p>Beispiele:</p>
@@ -677,7 +343,7 @@ idiv reg (value 1):</h3>
 mit Vorzeichen)</p>
 <h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und
 Bedinge Sprünge:</h2>
-<h3 id="cmp-reg-value-1-value-cmp-reg-value-1-reg-value-2">cmp reg
+<h3 id="cmp-reg-value-1-value--cmp-reg-value-1-reg-value-2">cmp reg
 (value 1), value / cmp reg (value 1), reg (value 2):</h3>
 <p>Definition: Vergleiche ein Register mit einem Wert bzw. mit dem Wert
 eines weiteren Registers. Diese Operation setzt Bits im Flag-Register
@@ -699,15 +365,11 @@ jmp .some_label
 ; [Do something]</code></pre>
 <h3 id="jx-some_label">j<em>X</em> some_label:</h3>
 <p>(<em>X</em> wird durch eine von vielen Bezeichnungen ersetzt:
-<code>je</code>, <code>jne</code>, …)</p>
+<code>je</code>, <code>jne</code>, ...)</p>
 <p>Definition: Springe, wenn bestimmte Bits im Flag-Register gesetzt
 sind. Dies wird in der Regel in Kombination mit einer
 Vergleich-Operation genutzt, um diese Bits zu setzen.</p>
 <table>
-<colgroup>
-<col style="width: 67%" />
-<col style="width: 32%" />
-</colgroup>
 <thead>
 <tr class="header">
 <th>Sprung Bezeichnung</th>
@@ -717,52 +379,52 @@ Vergleich-Operation genutzt, um diese Bits zu setzen.</p>
 <tbody>
 <tr class="odd">
 <td><code>je</code></td>
-<td>“Jump equal” – Springe, wenn der Vergleich ergeben hat, dass die
+<td>"Jump equal" -- Springe, wenn der Vergleich ergeben hat, dass die
 Werte die selben sind</td>
 </tr>
 <tr class="even">
 <td><code>jne</code></td>
-<td>“Jump not equal” – Springe, wenn der Vergleich ergeben hat, dass die
-Werte ungleich sind</td>
+<td>"Jump not equal" -- Springe, wenn der Vergleich ergeben hat, dass
+die Werte ungleich sind</td>
 </tr>
 <tr class="odd">
 <td><code>jb</code></td>
-<td>“Jump below” – Springe wenn <span class="math inline">\(\text{reg1}
+<td>"Jump below" -- Springe wenn <span class="math inline">\(\text{reg1}
 &lt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1}
 &lt; \text{value}\)</span> (unsigned number)</td>
 </tr>
 <tr class="even">
 <td><code>ja</code></td>
-<td>“Jump above” – Springe wenn <span class="math inline">\(\text{reg1}
+<td>"Jump above" -- Springe wenn <span class="math inline">\(\text{reg1}
 &gt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1}
 &gt; \text{value}\)</span> (unsigned number)</td>
 </tr>
 <tr class="odd">
 <td><code>jl</code></td>
-<td>“Jump less” – Springe wenn <span class="math inline">\(\text{reg1}
+<td>"Jump less" -- Springe wenn <span class="math inline">\(\text{reg1}
 &lt; \text{reg2}\)</span> oder <span class="math inline">\(\text{reg1}
 &lt; \text{value}\)</span> (signed number)</td>
 </tr>
 <tr class="even">
 <td><code>jg</code></td>
-<td>“Jump greater” – Springe wenn <span
+<td>"Jump greater" -- Springe wenn <span
 class="math inline">\(\text{reg1} &gt; \text{reg2}\)</span> oder <span
 class="math inline">\(\text{reg1} &gt; \text{value}\)</span> (signed
 number)</td>
 </tr>
 <tr class="odd">
 <td><code>jz</code></td>
-<td>“Jump zero” – Äquivalent zu <code>je</code>. Springe wenn das
+<td>"Jump zero" -- Äquivalent zu <code>je</code>. Springe wenn das
 Ergebnis 0 ist.</td>
 </tr>
 <tr class="even">
 <td><code>jnz</code></td>
-<td>“Jump not zero” – Äquivalent zu <code>jne</code>. Springe wenn das
+<td>"Jump not zero" -- Äquivalent zu <code>jne</code>. Springe wenn das
 Ergebnis nicht 0 ist.</td>
 </tr>
 <tr class="odd">
-<td><code>jle</code> / <code>jge</code> / …</td>
-<td>“Jump less equal” / “Jump greater equal” – Analog zu den Sprüngen
+<td><code>jle</code> / <code>jge</code> / ...</td>
+<td>"Jump less equal" / "Jump greater equal" -- Analog zu den Sprüngen
 oben nur mit equal</td>
 </tr>
 </tbody>
@@ -776,7 +438,7 @@ jl .some_label
 
 .some_label:
 ; execute here if rax &lt; 2</code></pre>
-<h3 id="test-reg-value-1-value-test-reg-value-1-reg-value-2">test reg
+<h3 id="test-reg-value-1-value--test-reg-value-1-reg-value-2">test reg
 (value 1), value / test reg (value 1), reg (value 2):</h3>
 <p>Definition: Führt ein logisches UND (<span
 class="math inline">\(\land\)</span>) auf das erste Register mit dem
@@ -806,8 +468,8 @@ werden zwei Werte vorgehalten: der (Stack-)Base-Pointer (oder
 Frame-Pointer) und der Stack-Pointer. Der Base-Pointer zeigt immer auf
 den Beginn des Stacks währenddessen der Stack-Pointer auf die nächste
 belegte Adresse zeigt. Der Stack wächst, wenn <code>rsp</code> kleiner
-wird. Daher “wächst” der Stack nach unten. (Der Stack ist “full
-descending”.)</p>
+wird. Daher "wächst" der Stack nach unten. (Der Stack ist "full
+descending".)</p>
 <p>WICHTIG: nach dem Funktionsaufruf (also vor dem ret Befehl) muss der
 Stack-Pointer wieder auf der selben Stelle sein wie zu Beginn des
 Funktionsaufrufs!</p>
@@ -854,7 +516,7 @@ some_other_function:
     ret</code></pre>
 <h1 id="assembly-tricks">Assembly-Tricks:</h1>
 <h3 id="ein-register-auf-0-setzen-clean-oder-bereinigen">Ein Register
-auf 0 setzen (“clean” oder “bereinigen”)</h3>
+auf 0 setzen ("clean" oder "bereinigen")</h3>
 <p>Um den Wert eines Registers auf 0 zu setzen könnt ihr einfach die
 Zahl 0 in das jeweilige Register setzen:</p>
 <pre><code>mov rax, 0 ; Setze rax = 0</code></pre>
@@ -879,31 +541,22 @@ id="ganzzahlige-multiplikationdivision-um-eine-zweier-potenz">Ganzzahlige
 Multiplikation/Division um eine zweier Potenz</h3>
 <p>Die Multiplikation bzw. die Division einer Zahl der Basis <span
 class="math inline">\(b\)</span> mit einer Zahl der Form <span
-class="math inline">\(b^n\)</span> kann als einfache “Verschiebung” um
+class="math inline">\(b^n\)</span> kann als einfache "Verschiebung" um
 <span class="math inline">\(n\)</span> Stellen betrachtet werden. Gucken
 wir uns dies zuerst im Dezimalsystem mit 10-er Potenzen an:</p>
-<p><span class="math display">\[\begin{align*}
-    12 \cdot 10^1 &amp;= 12 \cdot 10   &amp;&amp;= 120 \\
-    12 \cdot 10^2 &amp;= 12 \cdot 100  &amp;&amp;= 1200 \\
-    12 \cdot 10^3 &amp;= 12 \cdot 1000 &amp;&amp;= 12000
-\end{align*}\]</span></p>
-<p><span class="math display">\[\begin{align*}
-    12 \div 10^1 &amp;= 12 \div 10   &amp;&amp;= 1.2 \\
-    12 \div 10^2 &amp;= 12 \div 100  &amp;&amp;= 0.12 \\
-    12 \div 10^3 &amp;= 12 \div 1000 &amp;&amp;= 0.012
-\end{align*}\]</span></p>
+<p>\begin{align*} 12 \cdot 10^1 &amp;= 12 \cdot 10 &amp;&amp;= 120 \ 12
+\cdot 10^2 &amp;= 12 \cdot 100 &amp;&amp;= 1200 \ 12 \cdot 10^3 &amp;=
+12 \cdot 1000 &amp;&amp;= 12000 \end{align*}</p>
+<p>\begin{align*} 12 \div 10^1 &amp;= 12 \div 10 &amp;&amp;= 1.2 \ 12
+\div 10^2 &amp;= 12 \div 100 &amp;&amp;= 0.12 \ 12 \div 10^3 &amp;= 12
+\div 1000 &amp;&amp;= 0.012 \end{align*}</p>
 <p>Im Binärsystem gilt dieses Prinzip natürlich auch:</p>
-<p><span class="math display">\[\begin{align*}
-    0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10} &amp;&amp;= 0110_2
-\\
-    0011_2 \cdot 2_{10}^2 &amp;= 0011_2 \cdot 4_{10} &amp;&amp;= 1100_2
-\end{align*}\]</span></p>
-<p><span class="math display">\[\begin{align*}
-    0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10} &amp;&amp;=
-0001(.1000)_2 \\
-    0011_2 \div 2_{10}^2 &amp;= 0011_2 \div 4_{10} &amp;&amp;=
-0000(.1100)_2
-\end{align*}\]</span></p>
+<p>\begin{align*} 0011_2 \cdot 2_{10}^1 &amp;= 0011_2 \cdot 2_{10}
+&amp;&amp;= 0110_2 \ 0011_2 \cdot 2_{10}^2 &amp;= 0011_2 \cdot 4_{10}
+&amp;&amp;= 1100_2 \end{align*}</p>
+<p>\begin{align*} 0011_2 \div 2_{10}^1 &amp;= 0011_2 \div 2_{10}
+&amp;&amp;= 0001(.1000)<em>2 \ 0011_2 \div 2</em>{10}^2 &amp;= 0011_2
+\div 4_{10} &amp;&amp;= 0000(.1100)_2 \end{align*}</p>
 <p>Hinweise:</p>
 <ol type="1">
 <li>Wir geben mit den Subscripts die Basis der Zahlendarstellung
@@ -930,7 +583,8 @@ Verbindung zugreifen.</p>
 Command-Line und initiiert die Verbindung über SSH:</p>
 <pre><code>$ ssh ZEDAT_USER_NAME@andorra.imp.fu-berlin.de</code></pre>
 <p>Ähnlich funktioniert dies auch für die anderen Remote-Systeme der
-Uni: http://www.mi.fu-berlin.de/w/IT/ItServicesTerminalserver</p>
+Uni: <a
+href="http://www.mi.fu-berlin.de/w/IT/ItServicesTerminalserver">http://www.mi.fu-berlin.de/w/IT/ItServicesTerminalserver</a></p>
 <h2 id="copying-files-sshscp">Copying files (SSH/SCP)</h2>
 <p>Um Dateien von eurem System auf die Remotesysteme der Universität zu
 bekommen kann man das auf SSH basierende SCP (Secure-Copy-Protocol)
@@ -944,7 +598,7 @@ diese zunächst Compiled/Übersetzt werden. Dazu erstellt ihr zunächst mit
 Hilfe von NASM eine Objekt-Datei (<code>.o</code>) aus eurem
 Assembly-Code:</p>
 <pre><code>$ nasm -f elf64 -o PROGRAMM_NAME.o PROGRAMM_NAME.asm</code></pre>
-<p>Die Flag “-f elf64” teilt NASM mit, dass die Ausgabe für x64 Linux
+<p>Die Flag "-f elf64" teilt NASM mit, dass die Ausgabe für x64 Linux
 Übersetzt werden soll.</p>
 <p>Nun müsst ihr auch den C-Wrapper compilieren und eine weitere
 Objektdatei erzeugen:</p>
@@ -956,7 +610,7 @@ euren Code hat.</p>
 <p>Anschließend müssen wir noch beide Objektdateien zu einer
 <strong>ausführbaren Datei</strong> verlinken:</p>
 <pre><code>$ c99 -o PROGRAMM_NAME PROGRAMM_NAME_wrapper.o PROGRAMM_NAME.o</code></pre>
-<p>Abschließend solltet ihr eine Datei mit dem Namen “PROGRAMM_NAME”
+<p>Abschließend solltet ihr eine Datei mit dem Namen "PROGRAMM_NAME"
 besitzen. Diese könnt ihr wie folgt ausführen:</p>
 <pre><code>$ ./PROGRAMM_NAMME [parameter 1] [parameter 2] [parameter 3] ...</code></pre>
 <p>Alternativ könnt ihr auch einfach die gegebene MAKEFILE nutzen</p>
@@ -965,7 +619,7 @@ besitzen. Diese könnt ihr wie folgt ausführen:</p>
 <p>Um Einblick in die Ausführung des ASM-Codes zu bekommen kann man
 <code>gdb</code> verwenden. Hierzu findet ihr eine kleine
 Zusammenfassung von Befehlen zur Ausführung des <code>gdb</code> mit
-einer Terminal “UI”:</p>
+einer Terminal "UI":</p>
 <pre><code>$ gdb PROGRAMM_NAME                 Lade deinen code in gdb
 gdb&gt; break SOME_LABEL_IN_YOUR_CODE  Setze einen &quot;Breakpoint&quot; bei dem dein Programm hält
 gdb&gt; tui enable                     Aktiviere die UI
@@ -978,11 +632,16 @@ gdb&gt; quit                           Beende gdb
 $</code></pre>
 <h1 id="quellen">Quellen:</h1>
 <ul>
-<li>https://en.wikibooks.org/wiki/X86_Assembly/X86_Architecture</li>
-<li>https://en.wikipedia.org/wiki/X86_calling_conventions</li>
-<li>https://stackoverflow.com/questions/18024672/what-registers-are-preserved-through-a-linux-x86-64-function-call</li>
-<li>https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html</li>
-<li>https://cs61.seas.harvard.edu/site/2018/Asm1/</li>
+<li><a
+href="https://en.wikibooks.org/wiki/X86_Assembly/X86_Architecture">https://en.wikibooks.org/wiki/X86_Assembly/X86_Architecture</a></li>
+<li><a
+href="https://en.wikipedia.org/wiki/X86_calling_conventions">https://en.wikipedia.org/wiki/X86_calling_conventions</a></li>
+<li><a
+href="https://stackoverflow.com/questions/18024672/what-registers-are-preserved-through-a-linux-x86-64-function-call">https://stackoverflow.com/questions/18024672/what-registers-are-preserved-through-a-linux-x86-64-function-call</a></li>
+<li><a
+href="https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html">https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html</a></li>
+<li><a
+href="https://cs61.seas.harvard.edu/site/2018/Asm1/">https://cs61.seas.harvard.edu/site/2018/Asm1/</a></li>
 </ul>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -569,6 +569,13 @@ xor rdx, 0x8f
 1000 1111
 ---------
 0000 1011 = rdx</code></pre>
+<h3 id="not-reg-value-1">not reg (value 1):</h3>
+<p>Definition: Invertiert den Wert im ersten Register (alle 0en werden
+zu 1en und umgekehrt).</p>
+<p>Beispiel:</p>
+<pre><code>; rdx = 0011 1011
+neg rdx
+; rdx = 1100 0100</code></pre>
 <h3 id="shl-reg-value-1-value-shl-reg-value-1-cl">shl reg (value 1),
 value / shl reg (value 1), cl</h3>
 <p>Definition: Shifte den Wert des Registers um <span

--- a/index.html
+++ b/index.html
@@ -770,6 +770,7 @@ einer Terminal "UI":</p>
 gdb&gt; break SOME_LABEL_IN_YOUR_CODE  Setze einen &quot;Breakpoint&quot; bei dem dein Programm hält
 gdb&gt; tui enable                     Aktiviere die UI
 gdb&gt; layout asm                     Zeige den Assembly-Code deines Programms
+gdb&gt; set disassembly-flavor intel   Syntax wie gewohnt darstellen (mov rax,0x0 statt mov $0x0,%rax)
 gdb&gt; layout regs                    Zeige deine Register während des Programmlaufs
 gdb&gt; run                            Starte Ausführung des Programms
 gdb&gt; ni                             Next Instruction

--- a/index.html
+++ b/index.html
@@ -169,6 +169,131 @@ manuell vor dem Aufruf sichern.</p>
 </tr>
 </tbody>
 </table>
+<h1 id="befehle-übersicht">Befehle (Übersicht)</h1>
+<p>Notation: reg = Register (<code>rax</code>, ...), imm = Immediate
+(idR. eine Zahl)</p>
+<table>
+<thead>
+<tr class="header">
+<th>Befehl</th>
+<th>Arg1</th>
+<th>Arg2</th>
+<th>Bedeutung</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><a href="#mov-reg-to-value--mov-reg-to-reg-from">mov</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#and-reg1-value--and-reg1-reg2">and</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 &amp; reg2/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#or-reg1-value--or-reg1-reg2">or</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 | reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#xor-reg1-value--xor-reg1-reg2">xor</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 ^ reg2/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#not-reg1">not</a></td>
+<td>reg1</td>
+<td></td>
+<td>reg1 = ~reg1</td>
+</tr>
+<tr class="even">
+<td><a href="#shl-reg1-value--shl-reg1-cl">shl</a></td>
+<td>reg1</td>
+<td><code>cl</code>/imm</td>
+<td>reg1 = reg1 &lt;&lt; <code>cl</code>/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#shr-reg1-value--shr-reg1-cl">shr</a></td>
+<td>reg1</td>
+<td><code>cl</code>/imm</td>
+<td>reg1 = reg1 &gt;&gt; <code>cl</code>/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#neg-reg1">neg</a></td>
+<td>reg1</td>
+<td></td>
+<td>reg1 = -reg1 (2er Komplement)</td>
+</tr>
+<tr class="odd">
+<td><a href="#add-reg1-value--add-reg1-reg2">add</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 + reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#sub-reg1-value--sub-reg1-reg2">sub</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 - reg2/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#mul-reg1">mul</a></td>
+<td>reg1</td>
+<td></td>
+<td><code>rdx:rax</code> = <code>rax</code> * reg1 (unsigned)</td>
+</tr>
+<tr class="even">
+<td><a href="#div-reg1">div</a></td>
+<td>reg1</td>
+<td></td>
+<td><code>rax</code> = <code>rdx:rax</code> / reg1 (Rest in
+<code>rdx</code>)</td>
+</tr>
+<tr class="odd">
+<td><a href="#imul-reg1-und-idiv-reg1">imul</a></td>
+<td>reg1</td>
+<td></td>
+<td><code>rdx:rax</code> = <code>rax</code> * reg1 (signed)</td>
+</tr>
+<tr class="even">
+<td><a href="#imul-reg1-und-idiv-reg1">idiv</a></td>
+<td>reg1</td>
+<td></td>
+<td><code>rax</code> = <code>rdx:rax</code> / reg1 (Rest in
+<code>rdx</code>)</td>
+</tr>
+<tr class="odd">
+<td><a href="#cmp-reg1-value--cmp-reg1-reg2">cmp</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 - reg2/imm (setzt nur <code>rflags</code>)</td>
+</tr>
+<tr class="even">
+<td><a href="#test-reg1-value--test-reg1-reg2">test</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 ^ reg2/imm (setzt nur <code>rflags</code>)</td>
+</tr>
+<tr class="odd">
+<td><a href="#jmp-some_label">jmp</a></td>
+<td>label</td>
+<td></td>
+<td>Sprung zu label (<code>rip</code> = addr of label)</td>
+</tr>
+<tr class="even">
+<td><a href="#jx-some_label">j<em>X</em></a></td>
+<td>label</td>
+<td></td>
+<td>Bedingter Sprung (nur wenn Bedingung erfüllt)</td>
+</tr>
+</tbody>
+</table>
 <h1 id="befehle">Befehle</h1>
 <h2 id="bewegen-von-daten">Bewegen von Daten:</h2>
 <h3 id="mov-reg-to-value--mov-reg-to-reg-from">mov reg (to), value / mov
@@ -179,8 +304,8 @@ weiteres Register.</p>
 <pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
-<h3 id="and-reg-value-1-value--and-reg-value-1-reg-value-2">and reg
-(value 1), value / and reg (value 1), reg (value 2)</h3>
+<h3 id="and-reg1-value--and-reg1-reg2">and reg1, value / and reg1,
+reg2</h3>
 <p>Definition: Wendet das logische UND (<span
 class="math inline">\(\land\)</span>) mit dem Wert des zweiten
 Parameters auf den Wert des ersten Registers an und speichert das
@@ -198,8 +323,7 @@ and rax, rsi = 0101 1101 and 1101 1011
 1001 1011
 ---------
 0001 1001 = rax</code></pre>
-<h3 id="or-reg-value-1-value--or-reg-value-1-reg-value-2">or reg (value
-1), value / or reg (value 1), reg (value 2)</h3>
+<h3 id="or-reg1-value--or-reg1-reg2">or reg1, value / or reg1, reg2</h3>
 <p>Definition: Wende das logische ODER (<span
 class="math inline">\(\lor\)</span>) mit dem Wert des zweiten Parameters
 auf das erste Register an und speichert das Ergebnis im ersten
@@ -217,8 +341,8 @@ or rdx, 0xf = 0011 1101 or 0000 1101
 0000 1101
 ---------
 0011 1101 = rdx</code></pre>
-<h3 id="xor-reg-value-1-value--xor-reg-value-1-reg-value-2">xor reg
-(value 1), value / xor reg (value 1), reg (value 2):</h3>
+<h3 id="xor-reg1-value--xor-reg1-reg2">xor reg1, value / xor reg1,
+reg2:</h3>
 <p>Definition: Wendet das logische XOR (<span
 class="math inline">\(\oplus\)</span>) mit dem Wert des zweiten
 Parameters auf den Wert des ersten Registers an.</p>
@@ -235,15 +359,14 @@ xor rdx, 0x8f
 1000 1111
 ---------
 0000 1011 = rdx</code></pre>
-<h3 id="not-reg-value-1">not reg (value 1):</h3>
+<h3 id="not-reg1">not reg1:</h3>
 <p>Definition: Invertiert den Wert im ersten Register (alle 0en werden
 zu 1en und umgekehrt).</p>
 <p>Beispiel:</p>
 <pre><code>; rdx = 0011 1011
 neg rdx
 ; rdx = 1100 0100</code></pre>
-<h3 id="shl-reg-value-1-value--shl-reg-value-1-cl">shl reg (value 1),
-value / shl reg (value 1), cl</h3>
+<h3 id="shl-reg1-value--shl-reg1-cl">shl reg1, value / shl reg1, cl</h3>
 <p>Definition: Shifte den Wert des Registers um <span
 class="math inline">\(n\)</span> Stellen nach Links. Bits die nach Links
 "rausgeschoben" werden gehen verloren</p>
@@ -261,8 +384,7 @@ shl rax, 1
 begründet, dass bei der Entwicklung eines x86-Chips nur eine Verbindung
 des Count-Registers (<code>cl</code>) angelegt wurde für
 Verschiebungen.</p>
-<h3 id="shr-reg-value-1-value--shr-reg-value-1-cl">shr reg (value 1),
-value / shr reg (value 1), cl</h3>
+<h3 id="shr-reg1-value--shr-reg1-cl">shr reg1, value / shr reg1, cl</h3>
 <p>Definition: Shifte den Wert des Registers um n Stellen nach Rechts.
 Also analog zu <code>shl</code>.</p>
 <p>Beispiel:</p>
@@ -272,8 +394,8 @@ shr rax, 1</code></pre>
 nur das Register <code>cl</code> als Registerverschiebungswert nutzen!
 Bei der Entwicklung der x86-Chips wurde nur eine Verbindung des
 Count-Registers (<code>cl</code>) für Verschiebungen angelegt.</p>
-<h3 id="rol-reg-value-1-value--rol-reg-value-1-reg-value-2">rol reg
-(value 1), value / rol reg (value 1), reg (value 2)</h3>
+<h3 id="rol-reg1-value--rol-reg1-reg2">rol reg1, value / rol reg1,
+reg2</h3>
 <p>Definition: Rotiere die Werte um <span
 class="math inline">\(n\)</span> Stellen. Dies ist Analog zu shl jedoch
 gehen hier die Bits die nach links raus geschoben werden nicht verloren,
@@ -286,8 +408,8 @@ rol rax, 1</code></pre>
 
 rol rax, 1
 =&gt; rax = 1000 1001</code></pre>
-<h3 id="ror-reg-value-1-value--ror-reg-value-1-reg-value-2">ror reg
-(value 1), value / ror reg (value 1), reg (value 2)</h3>
+<h3 id="ror-reg1-value--ror-reg1-reg2">ror reg1, value / ror reg1,
+reg2</h3>
 <p>Definition: Rotiere die Werte um <span
 class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <code>rol</code></p>
@@ -295,25 +417,25 @@ class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <pre><code>ror rax, rdx
 ror rax, 1</code></pre>
 <h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
-<h3 id="neg-reg-value-1">neg reg (value 1):</h3>
+<h3 id="neg-reg1">neg reg1:</h3>
 <p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
 Komplement).</p>
 <p>Beispiel:</p>
 <pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
-<h3 id="add-reg-value-1-value--add-reg-value-1-reg-value-2">add reg
-(value 1), value / add reg (value 1), reg (value 2):</h3>
+<h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
+reg2:</h3>
 <p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
 Wert eines anderen Registers.</p>
 <p>Beispiel:</p>
 <pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
 add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
-<h3 id="sub-reg-value-1-value--sub-reg-value-1-reg-value-2">sub reg
-(value 1), value / sub reg (value 1), reg (value 2):</h3>
+<h3 id="sub-reg1-value--sub-reg1-reg2">sub reg1, value / sub reg1,
+reg2:</h3>
 <p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
 <p>Beispiele:</p>
 <pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
 sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
-<h3 id="mul-reg-value-1">mul reg (value 1):</h3>
+<h3 id="mul-reg1">mul reg1:</h3>
 <p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
 angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>
 Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in
@@ -325,7 +447,7 @@ Falls man das Register rax mit einem bestimmten Wert multiplizieren
 möchte muss man diesen vorher in ein Register verschieben:</p>
 <pre><code>mov rsi, 3
 mul rsi    ; Multipliziere rax mit 3</code></pre>
-<h3 id="div-reg-value-1">div reg (value 1):</h3>
+<h3 id="div-reg1">div reg1:</h3>
 <p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax)
 durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
 (ganzzahlige Division) und rdx (Rest) gespeichert</p>
@@ -337,14 +459,13 @@ Muster:</p>
 <pre><code>mov rsi, 3
 mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
 div rsi    ; Dividiere rax durch 3</code></pre>
-<h3 id="imul-reg-value-1-und-idiv-reg-value-1">imul reg (value 1) und
-idiv reg (value 1):</h3>
+<h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
 <p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen
 mit Vorzeichen)</p>
 <h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und
 Bedinge Sprünge:</h2>
-<h3 id="cmp-reg-value-1-value--cmp-reg-value-1-reg-value-2">cmp reg
-(value 1), value / cmp reg (value 1), reg (value 2):</h3>
+<h3 id="cmp-reg1-value--cmp-reg1-reg2">cmp reg1, value / cmp reg1,
+reg2:</h3>
 <p>Definition: Vergleiche ein Register mit einem Wert bzw. mit dem Wert
 eines weiteren Registers. Diese Operation setzt Bits im Flag-Register
 die später für Bedingte-Sprünge verwendet werden könnten</p>
@@ -438,8 +559,8 @@ jl .some_label
 
 .some_label:
 ; execute here if rax &lt; 2</code></pre>
-<h3 id="test-reg-value-1-value--test-reg-value-1-reg-value-2">test reg
-(value 1), value / test reg (value 1), reg (value 2):</h3>
+<h3 id="test-reg1-value--test-reg1-reg2">test reg1, value / test reg1,
+reg2:</h3>
 <p>Definition: Führt ein logisches UND (<span
 class="math inline">\(\land\)</span>) auf das erste Register mit dem
 Wert des zweiten Registers bzw. dem angegebenen Wert aus. Das Ergebnis

--- a/index.html
+++ b/index.html
@@ -189,104 +189,122 @@ manuell vor dem Aufruf sichern.</p>
 <td>reg1 = reg2/imm</td>
 </tr>
 <tr class="even">
-<td><a href="#and-reg1-value--and-reg1-reg2">and</a></td>
-<td>reg1</td>
-<td>reg2/imm</td>
-<td>reg1 = reg1 &amp; reg2/imm</td>
-</tr>
-<tr class="odd">
-<td><a href="#or-reg1-value--or-reg1-reg2">or</a></td>
-<td>reg1</td>
-<td>reg2/imm</td>
-<td>reg1 = reg1 | reg2/imm</td>
-</tr>
-<tr class="even">
-<td><a href="#xor-reg1-value--xor-reg1-reg2">xor</a></td>
-<td>reg1</td>
-<td>reg2/imm</td>
-<td>reg1 = reg1 ^ reg2/imm</td>
-</tr>
-<tr class="odd">
-<td><a href="#not-reg1">not</a></td>
-<td>reg1</td>
 <td></td>
-<td>reg1 = ~reg1</td>
-</tr>
-<tr class="even">
-<td><a href="#shl-reg1-value--shl-reg1-cl">shl</a></td>
-<td>reg1</td>
-<td><code>cl</code>/imm</td>
-<td>reg1 = reg1 &lt;&lt; <code>cl</code>/imm</td>
+<td></td>
+<td></td>
+<td></td>
 </tr>
 <tr class="odd">
-<td><a href="#shr-reg1-value--shr-reg1-cl">shr</a></td>
-<td>reg1</td>
-<td><code>cl</code>/imm</td>
-<td>reg1 = reg1 &gt;&gt; <code>cl</code>/imm</td>
-</tr>
-<tr class="even">
 <td><a href="#add-reg1-value--add-reg1-reg2">add</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 = reg1 + reg2/imm</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="#sub-reg1-value--sub-reg1-reg2">sub</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 = reg1 - reg2/imm</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#neg-reg1">neg</a></td>
 <td>reg1</td>
 <td></td>
 <td>reg1 = -reg1 (2er Komplement)</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="#mul-reg1">mul</a></td>
 <td>reg1</td>
 <td></td>
 <td><code>rdx:rax</code> = <code>rax</code> * reg1 (unsigned)</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#div-reg1">div</a></td>
 <td>reg1</td>
 <td></td>
 <td><code>rax</code> = <code>rdx:rax</code> / reg1 (Rest in
 <code>rdx</code>)</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="#imul-reg1-und-idiv-reg1">imul</a></td>
 <td>reg1</td>
 <td></td>
 <td><code>rdx:rax</code> = <code>rax</code> * reg1 (signed)</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#imul-reg1-und-idiv-reg1">idiv</a></td>
 <td>reg1</td>
 <td></td>
 <td><code>rax</code> = <code>rdx:rax</code> / reg1 (Rest in
 <code>rdx</code>)</td>
 </tr>
+<tr class="even">
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
 <tr class="odd">
+<td><a href="#and-reg1-value--and-reg1-reg2">and</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 &amp; reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#or-reg1-value--or-reg1-reg2">or</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 | reg2/imm</td>
+</tr>
+<tr class="odd">
+<td><a href="#xor-reg1-value--xor-reg1-reg2">xor</a></td>
+<td>reg1</td>
+<td>reg2/imm</td>
+<td>reg1 = reg1 ^ reg2/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#not-reg1">not</a></td>
+<td>reg1</td>
+<td></td>
+<td>reg1 = ~reg1</td>
+</tr>
+<tr class="odd">
+<td><a href="#shl-reg1-value--shl-reg1-cl">shl</a></td>
+<td>reg1</td>
+<td><code>cl</code>/imm</td>
+<td>reg1 = reg1 &lt;&lt; <code>cl</code>/imm</td>
+</tr>
+<tr class="even">
+<td><a href="#shr-reg1-value--shr-reg1-cl">shr</a></td>
+<td>reg1</td>
+<td><code>cl</code>/imm</td>
+<td>reg1 = reg1 &gt;&gt; <code>cl</code>/imm</td>
+</tr>
+<tr class="odd">
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="even">
 <td><a href="#cmp-reg1-value--cmp-reg1-reg2">cmp</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 - reg2/imm (setzt nur <code>rflags</code>)</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#test-reg1-value--test-reg1-reg2">test</a></td>
 <td>reg1</td>
 <td>reg2/imm</td>
 <td>reg1 ^ reg2/imm (setzt nur <code>rflags</code>)</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="#jmp-some_label">jmp</a></td>
 <td>label</td>
 <td></td>
 <td>Sprung zu label (<code>rip</code> = addr of label)</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="#jx-some_label">j<em>X</em></a></td>
 <td>label</td>
 <td></td>
@@ -303,6 +321,52 @@ weiteres Register.</p>
 <p>Beispiel:</p>
 <pre><code>mov rax, rdx ; Verschiebe Wert von rdx in rax (ergo rax = rdx)
 mov rsi, 2   ; Verschiebe die Zahl 2 in das Register rsi (ergo rsi = 2)</code></pre>
+<h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
+<h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
+reg2:</h3>
+<p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
+Wert eines anderen Registers.</p>
+<p>Beispiel:</p>
+<pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
+add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
+<h3 id="sub-reg1-value--sub-reg1-reg2">sub reg1, value / sub reg1,
+reg2:</h3>
+<p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
+<p>Beispiele:</p>
+<pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
+sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
+<h3 id="neg-reg1">neg reg1:</h3>
+<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
+Komplement).</p>
+<p>Beispiel:</p>
+<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
+<h3 id="mul-reg1">mul reg1:</h3>
+<p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
+angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>
+Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in
+rax passiert)</p>
+<p>Beispiel:</p>
+<pre><code>mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</code></pre>
+<p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden.
+Falls man das Register rax mit einem bestimmten Wert multiplizieren
+möchte muss man diesen vorher in ein Register verschieben:</p>
+<pre><code>mov rsi, 3
+mul rsi    ; Multipliziere rax mit 3</code></pre>
+<h3 id="div-reg1">div reg1:</h3>
+<p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax)
+durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
+(ganzzahlige Division) und rdx (Rest) gespeichert</p>
+<p>Beispiel:</p>
+<pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
+<p>ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax. Also
+aufpassen, dass nicht ungewollt noch was in rdx steht. Übliches
+Muster:</p>
+<pre><code>mov rsi, 3
+mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
+div rsi    ; Dividiere rax durch 3</code></pre>
+<h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
+<p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen
+mit Vorzeichen)</p>
 <h2 id="bit-operationen">Bit-Operationen:</h2>
 <h3 id="and-reg1-value--and-reg1-reg2">and reg1, value / and reg1,
 reg2</h3>
@@ -416,52 +480,6 @@ class="math inline">\(n\)</span> Stellen nach Rechts. Also analog zu
 <p>Beispiel:</p>
 <pre><code>ror rax, rdx
 ror rax, 1</code></pre>
-<h2 id="arithmetische-operationen">Arithmetische-Operationen:</h2>
-<h3 id="add-reg1-value--add-reg1-reg2">add reg1, value / add reg1,
-reg2:</h3>
-<p>Definition: Addiere einen Wert bzw. den Wert eines Registers auf den
-Wert eines anderen Registers.</p>
-<p>Beispiel:</p>
-<pre><code>add rax, rdx ; Addiere Wert von rdx auf rax und Speicher Ergebnis in rax (rax = rax + rdx)
-add rsi, 2   ; Addiere die Zahl 2 auf rsi und Speicher Ergebnis in rsi (rsi = rsi + 2)</code></pre>
-<h3 id="sub-reg1-value--sub-reg1-reg2">sub reg1, value / sub reg1,
-reg2:</h3>
-<p>Definition: Analog zu <code>add</code> jedoch als Subtraktion</p>
-<p>Beispiele:</p>
-<pre><code>sub rax, rdx ; Subtrahiere von rax den Wert von rdx und speichere das Ergebnis in rax (rax = rax - rdx)
-sub rsi, 2   ; Subtrahiere von rsi den Wert 2 (rsi = rsi - 2)</code></pre>
-<h3 id="neg-reg1">neg reg1:</h3>
-<p>Definition: Negiere den Wert aus dem gegebenen Register (in 2er
-Komplement).</p>
-<p>Beispiel:</p>
-<pre><code>neg rsi ; Negiere den Wert in rsi</code></pre>
-<h3 id="mul-reg1">mul reg1:</h3>
-<p>Definition: Multipliziere den Wert in Register rax mit dem Wert des
-angegebenen Registers. Das Ergebnis wird in die <em>beiden (!!!)</em>
-Register rax und rdx gespeichert (rdx, falls ein Überlauf der Zahl in
-rax passiert)</p>
-<p>Beispiel:</p>
-<pre><code>mul rsi ; Multipliziere den Wert in rax mit dem Wert aus rsi und speichere das Ergebnis in (rdx) rax</code></pre>
-<p>ACHTUNG: Dieser Befehl kann nicht mit einem Wert genutzt werden.
-Falls man das Register rax mit einem bestimmten Wert multiplizieren
-möchte muss man diesen vorher in ein Register verschieben:</p>
-<pre><code>mov rsi, 3
-mul rsi    ; Multipliziere rax mit 3</code></pre>
-<h3 id="div-reg1">div reg1:</h3>
-<p>Definition: Dividiere den Wert aus rdx:rax (rdx konkateniert mit rax)
-durch den Wert aus dem angegebenen Register. Ergebnis wird in rax
-(ganzzahlige Division) und rdx (Rest) gespeichert</p>
-<p>Beispiel:</p>
-<pre><code>div rsi ; Dividiert rdx:rax durch den Wert in rsi. Rest wird in rdx gespeichert und Wert der ganzzahligen Division in rax</code></pre>
-<p>ACHTUNG: Der Divisor ist nicht nur rax, sondern rdx:rax. Also
-aufpassen, dass nicht ungewollt noch was in rdx steht. Übliches
-Muster:</p>
-<pre><code>mov rsi, 3
-mov rdx, 0 ; Sicherstellen, dass obere 64 Bit des Divisors 0 sind
-div rsi    ; Dividiere rax durch 3</code></pre>
-<h3 id="imul-reg1-und-idiv-reg1">imul reg1 und idiv reg1:</h3>
-<p>Definition: Analog zu mul/div, aber mit signed Zahlen (d.h. Zahlen
-mit Vorzeichen)</p>
 <h2 id="vergleichesprünge-und-bedinge-sprünge">Vergleiche/Sprünge und
 Bedinge Sprünge:</h2>
 <h3 id="cmp-reg1-value--cmp-reg1-reg2">cmp reg1, value / cmp reg1,

--- a/index.html
+++ b/index.html
@@ -781,6 +781,10 @@ href="https://stackoverflow.com/questions/18024672/what-registers-are-preserved-
 href="https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html">https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html</a></li>
 <li><a
 href="https://cs61.seas.harvard.edu/site/2018/Asm1/">https://cs61.seas.harvard.edu/site/2018/Asm1/</a></li>
+<li><a
+href="https://www.felixcloutier.com/x86/">https://www.felixcloutier.com/x86/</a>
+(all x86 instructions, including detailled description e.g. affected
+flags)</li>
 </ul>
 </body>
 </html>


### PR DESCRIPTION
Saw a student struggling with a subtle mistake (they forgot clearing `rdx` before `div`), turns out they hadn't read through the long explanation for the different instructions.

While the long text is nice, with description, examples etc. I felt that a shorter overview over the different instructions (including a description showing the `rdx:rax` behavior of `mul`/`div`) would be helpful.

While at it, I decided to make some more formatting changes :)